### PR TITLE
Rewrite scheduler and fix clock timing

### DIFF
--- a/sardine/__init__.py
+++ b/sardine/__init__.py
@@ -1,20 +1,28 @@
+# https://stackoverflow.com/questions/53689193/how-to-handle-exceptions-from-any-task-in-an-event-loop
+
+import asyncio
+from functools import wraps
+import pathlib
+import warnings
+
+from rich import print
+from rich.console import Console
+from rich.markdown import Markdown
+try:
+    import uvloop
+except ImportError:
+    warnings.warn('uvloop is not installed, rhythm accuracy may be impacted')
+else:
+    uvloop.install()
+
 from .clock.Clock import Clock
 from .superdirt.Sound import Sound as S
 from .superdirt.AutoBoot import (
         SuperColliderProcess,
         find_startup_file,
         find_synth_directory)
-from rich import print
-from rich.console import Console
-from rich.markdown import Markdown
-from functools import wraps
-from random import random, randint, choice
-from itertools import cycle
-import uvloop
-import platform
-import asyncio
-import pathlib
-import warnings
+
+warnings.filterwarnings("ignore")
 
 def print_pre_alpha_todo() -> None:
     """ Print the TODOlist from pre-alpha version """
@@ -42,11 +50,6 @@ coding. Check the examples/ folder to learn more. :)
 print(f"[red]{sardine}[/red]")
 print_pre_alpha_todo()
 print('\n')
-
-# UVLoop is not supported on Windows
-if platform.system() != "Windows":
-    uvloop.install()
-warnings.filterwarnings("ignore")
 
 c = Clock()
 cs = c.schedule

--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
+import inspect
 import traceback
 from typing import Callable, Coroutine, TYPE_CHECKING
 
@@ -99,7 +100,11 @@ class AsyncRunner:
             if initial:
                 await self._wait(0)
             else:
-                delay = state.kwargs.get('delay', 1)
+                delay = state.kwargs.get('delay')
+                if delay is None:
+                    param = inspect.signature(state.func).parameters.get('delay')
+                    delay = getattr(param, 'default', 1)
+
                 await self._wait(delay)
 
             try:
@@ -119,7 +124,7 @@ class AsyncRunner:
         print(f'[Stopped {name}]')
         self.clock.runners.pop(name)
 
-    async def _wait(self, delay: int):
+    async def _wait(self, delay: float | int):
         clock = self.clock
 
         if delay == 0:

--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -1,8 +1,146 @@
-from dataclasses import dataclass
-from typing import Awaitable
+import asyncio
+from dataclasses import dataclass, field
+import traceback
+from typing import Callable, Coroutine, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .Clock import Clock
+
+CoroFunc = Callable[..., Coroutine]
+
+
+@dataclass
+class FunctionState:
+    func: CoroFunc
+    args: tuple
+    kwargs: dict
+
 
 @dataclass
 class AsyncRunner:
-    function: Awaitable
-    function_save: Awaitable
-    last_valid_function: Awaitable
+    """Handles calling synchronizing and running a function in
+    the background, with support for run-time function patching.
+
+    This class should only be used through a Clock instance via
+    the `Clock.schedule()` method.
+
+    """
+    clock: "Clock"
+    states: list[FunctionState] = field(default_factory=list)
+
+    _swimming: bool = False
+    _stop: bool = False
+    _task: asyncio.Task | None = None
+
+    def push(self, func: CoroFunc, *args, **kwargs):
+        """Pushes a function state to the runner to be called in
+        the next iteration."""
+        if not self.states or func is not self.states[-1].func:
+            return self.states.append(FunctionState(func, args, kwargs))
+
+        # patch the top-most state
+        state = self.states[-1]
+        state.args = args
+        state.kwargs = kwargs
+
+    def start(self):
+        """Initializes the background runner task.
+
+        :raises RuntimeError:
+            This method was called after the task already started.
+
+        """
+        if self._task is not None:
+            raise RuntimeError('runner task has already started')
+
+        self.swim()
+        self._task = asyncio.create_task(self._runner())
+        self._task.add_done_callback(asyncio.Task.result)
+
+    def started(self) -> bool:
+        """Returns True if the runner has been started.
+
+        This method will remain true even if the runner stops afterwards.
+
+        """
+        return self._task is not None
+
+    def swim(self):
+        """Allows the runner to continue the next iteration.
+        This method must be called continuously to keep the runner alive."""
+        self._swimming = True
+
+    def stop(self):
+        """Stops the runner's execution after the current iteration.
+
+        This method takes precedence when `swim()` is also called.
+
+        """
+        self._stop = True
+
+    async def _runner(self):
+        initial = True
+        last_state = self.states[-1]
+        name = last_state.func.__name__
+        print(f'[Init {name}]')
+
+        while self.states and not self._stop:
+            # `state.func` must schedule itself to keep swimming
+            self._swimming = False
+            state = self.states[-1]
+            name = state.func.__name__
+
+            if state is not last_state:
+                pushed = len(self.states) > 1 and self.states[-2] is last_state
+                print(f'[Reloaded {name}]' if pushed else f'[Restored {name}]')
+                last_state = state
+
+            # Introspect arguments to synchronize
+            if initial:
+                await self._wait(0)
+            else:
+                delay = state.kwargs.get('delay', 1)
+                await self._wait(delay)
+
+            try:
+                await state.func(*state.args, **state.kwargs)
+            except asyncio.CancelledError:
+                # assume the user has intentionally cancelled
+                return
+            except Exception as e:
+                print(f'Exception encountered in {name}:')
+                traceback.print_exception(e)
+
+                self._revert_state()
+
+            initial = False
+
+        # Remove from clock
+        print(f'[Stopped {name}]')
+        self.clock.runners.pop(name)
+
+    async def _wait(self, delay: int):
+        clock = self.clock
+
+        if delay == 0:
+            cur_bar = clock.elapsed_bars
+            while clock.phase != 1 and clock.elapsed_bars != cur_bar + 1:
+                await asyncio.sleep(self._wait_resolution)
+        else:
+            next_time = clock.get_tick_time() + delay * clock.ppqn
+            while clock.tick_time < next_time:
+                await asyncio.sleep(self._wait_resolution)
+
+    @property
+    def _wait_resolution(self):
+        # Sleep resolution may be increased here
+        return self.clock._get_tick_duration() / (self.clock.ppqn * 2)
+
+    def _revert_state(self):
+        failed = self.states.pop()
+
+        if self.states:
+            # patch the global scope so recursive functions don't
+            # invoke the failed function
+            reverted = self.states[-1]
+            failed.func.__globals__[failed.func.__name__] = reverted.func

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -217,7 +217,7 @@ class Clock:
         async def _clock_update():
             """ Things the clock should do every tick """
 
-            self.tick_duration = self._get_tick_duration() - self.delta
+            self.tick_duration = self._get_tick_duration()
 
             begin = time.perf_counter()
             self.delta = 0
@@ -237,7 +237,7 @@ class Clock:
 
             # End of it
             end = time.perf_counter()
-            self.delta = end - begin
+            self.delta = end - begin - self.tick_duration
             if self._debug:
                 self.log()
 

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -116,7 +116,7 @@ class Clock:
         if runner is None:
             runner = self.runners[name] = AsyncRunner(self)
 
-        runner.push(func, *args, *kwargs)
+        runner.push(func, *args, **kwargs)
         if not runner.started():
             runner.start()
 

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -1,27 +1,18 @@
 import asyncio
-from dataclasses import dataclass
 import inspect
 import itertools
 import mido
 from rich import print
 import time
-import traceback
 from typing import Callable, Coroutine, Union
+
+from .AsyncRunner import AsyncRunner
 from ..io.MidiIo import MIDIIo
 
-
-# Aliases
+# Aliases
 atask = asyncio.create_task
 sleep = asyncio.sleep
 CoroFunc = Callable[..., Coroutine]
-
-
-@dataclass
-class AsyncRunner:
-    """Stores the arguments required to call the `Clock._runner()` method."""
-    func: Callable
-    args: tuple
-    kwargs: dict
 
 
 class Clock:
@@ -44,7 +35,7 @@ class Clock:
         self._midi = MIDIIo(port_name=port_name)
 
         # Clock maintenance related
-        self.func_runners: dict[str, list[AsyncRunner]] = {}
+        self.runners: dict[str, AsyncRunner] = {}
 
         self.running = False
         self._debug = False
@@ -115,96 +106,34 @@ class Clock:
     # ---------------------------------------------------------------------- #
     # Scheduler methods
 
-    def schedule(self, func: CoroFunc, *args, **kwargs):
+    def schedule(self, func: CoroFunc, /, *args, **kwargs):
         """Schedules the given function to be executed."""
         if not inspect.iscoroutinefunction(func):
             raise TypeError(f'func must be a coroutine function, not {type(func).__name__}')
 
         name = func.__name__
-        runners = self.func_runners.get(name)
+        runner = self.runners.get(name)
+        if runner is None:
+            runner = self.runners[name] = AsyncRunner(self)
 
-        if runners is None:
-            runners = self.func_runners[name] = []
-
-        initial = False
-
-        if not runners or func is not runners[-1].func:
-            # initialize with new runner
-            runner = AsyncRunner(func, args, kwargs)
-            runners.append(runner)
-            initial = True
-        else:
-            # update the top-most runner with new arguments
-            runner = runners[-1]
-            runner.args = args
-            runner.kwargs = kwargs
-
-        atask(self._runner(func, *args, initial=initial, **kwargs))
-
-    async def _runner(self, func, *args, initial: bool, **kwargs):
-        name = func.__name__
-        cur_bar = self.elapsed_bars
-
-        delay = kwargs.get('delay', 1)
-        delay = delay * self.ppqn
-
-
-        if initial:
-            print(f"[Init {name}]")
-            while (self.phase != 1 and self.elapsed_bars != cur_bar + 1):
-                await sleep(self._get_tick_duration() / (self.ppqn * 2))
-        else:
-            # Busy waiting until execution time
-            next_time = self.get_tick_time() + delay
-            while self.tick_time < next_time:
-                # You might increase the resolution even more
-                await sleep(self._get_tick_duration() / (self.ppqn * 2))
-
-        try:
-            await func(*args, **kwargs)
-        except asyncio.CancelledError:
-            # assume the user has intentionally cancelled and ignore
-            return
-        except Exception as e:
-            print(f'Exception encountered in {name}:')
-            traceback.print_exception(e)
-            self._reschedule(func)
-
-    def _reschedule(self, func: CoroFunc):
-        """
-        Removes the previous AsyncRunner instance for a given function
-        and dispatches any AsyncRunner before it, if it exists.
-        """
-        # pre: runners is not empty
-        runners = self.func_runners[func.__name__]
-        runners.pop()
-
-        if not runners:
-            return
-
-        # reschedule the previous function invoked
-        r = runners[-1]
-
-        # patch the global scope so recursive functions don't
-        # invoke the failed function
-        func.__globals__[func.__name__] = r.func
-
-        atask(self._runner(r.func, r.args, r.kwargs))
-
+        runner.push(func, *args, *kwargs)
+        if not runner.started():
+            runner.start()
 
     # ---------------------------------------------------------------------- #
     # Public methods
 
-    def remove(self, function: CoroFunc):
-        """ Remove a function from the scheduler """
-        self.func_runners.pop(function.__name__)
+    def remove(self, func: CoroFunc, /):
+        """Schedules the given function to stop execution."""
+        runner = self.runners[func.__name__]
+        runner.stop()
 
     def get_phase(self):
         return self.phase
 
     def print_children(self):
         """ Print all children on clock """
-        [print(child) for child in self.func_runners]
+        [print(child) for child in self.runners]
 
     def ticks_to_next_bar(self) -> None:
         """ How many ticks until next bar? """


### PR DESCRIPTION
## Summary
The `AsyncRunner` class is now dedicated to handling of one runner task per scheduled function. When the `Clock.schedule()` method is called consecutively, it notifies the existing AsyncRunner task to continue in the next iteration, rather than starting up a new runner task to handle a single iteration.

In addition, separate messages are shown when the function state is reloaded or has to be restored. `Clock.schedule()` will now introspect the default value for the `delay=` parameter in submitted functions if the function is (re)scheduled without a delay argument.

A fix is also included for `Clock.run_clock()` incrementing the clock phase too quickly.

ImportError is now caught when importing `uvloop`, since the package cannot be installed on Windows.

Demonstration:
```py
>>> async def bd(delay=1):
...     S('bd').out()
...     cs(bd)
>>> cs(bd)
[Init bd]

>>> async def bd(delay=2):
...     S('bd').out()
...     cs(bd)
[Reloaded bd]

>>> async def bd(): raise Exception
[Reloaded bd]
Exception encountered in bd:
Traceback (most recent call last):
  File "\Sardine\sardine\clock\AsyncRunner.py", line 111, in _runner
    await state.func(*state.args, **state.kwargs)
  File "<console>", line 1, in bd
Exception
[Restored bd]

>>> cr(bd)
[Stopped bd]
```