### PR TITLE
Allow importing objects from packages directly

### DIFF
--- a/sardine/__init__.py
+++ b/sardine/__init__.py
@@ -13,16 +13,15 @@ except ImportError:
 else:
     uvloop.install()
 
-from .io.UserConfig import read_user_configuration
-from .clock.Clock import Clock
-from .superdirt.SuperDirt import SuperDirt as Sound
-from .superdirt.AutoBoot import (
+from .io import read_user_configuration
+from .clock import Clock
+from .superdirt import (
         SuperColliderProcess,
         find_startup_file,
         find_synth_directory)
-from .io.Osc import Client as OSC
+from .io import Client as OSC
 from typing import Union
-from .sequences.Sequence import (
+from .sequences import (
         bin, euclid)
 
 warnings.filterwarnings("ignore")

--- a/sardine/__init__.py
+++ b/sardine/__init__.py
@@ -21,8 +21,7 @@ from .superdirt import (
         find_synth_directory)
 from .io import Client as OSC
 from typing import Union
-from .sequences import (
-        bin, euclid)
+from .sequences import *
 
 warnings.filterwarnings("ignore")
 

--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -5,9 +5,10 @@ import inspect
 import traceback
 from typing import Any, Callable, TYPE_CHECKING, Union
 
-
 if TYPE_CHECKING:
-    from .Clock import Clock
+    from . import Clock
+
+__all__ = ('AsyncRunner', 'FunctionState')
 
 
 def _assert_function_signature(sig: inspect.Signature, args, kwargs):

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -7,9 +7,11 @@ from rich import print
 import time
 from typing import Awaitable, Callable, Optional, Union
 
-from .AsyncRunner import AsyncRunner
-from ..io.MidiIo import MIDIIo
-from ..superdirt.SuperDirt import SuperDirt
+from . import AsyncRunner
+from ..io import MIDIIo
+from ..superdirt import SuperDirt
+
+__all__ = ('Clock', 'TickHandle')
 
 
 @functools.total_ordering

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -2,10 +2,11 @@ import asyncio
 import functools
 import heapq
 import inspect
-import mido
-from rich import print
 import time
 from typing import Awaitable, Callable, Optional, Union
+
+import mido
+from rich import print
 
 from . import AsyncRunner
 from ..io import MIDIIo

--- a/sardine/clock/__init__.py
+++ b/sardine/clock/__init__.py
@@ -1,0 +1,2 @@
+from .AsyncRunner import *
+from .Clock import *

--- a/sardine/io/MidiIo.py
+++ b/sardine/io/MidiIo.py
@@ -5,6 +5,9 @@ from rich.console import Console
 from rich import print
 import asyncio
 
+__all__ = ('MIDIIo',)
+
+
 class MIDIIo(threading.Thread):
 
     """

--- a/sardine/io/MidiListener.py
+++ b/sardine/io/MidiListener.py
@@ -1,6 +1,9 @@
 import mido
 from mido import open_output
 
+__all__ = ('MidiListener',)
+
+
 class MidiListener():
 
     """

--- a/sardine/io/Osc.py
+++ b/sardine/io/Osc.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 from time import time
-from osc4py3.as_eventloop import (osc_startup, osc_udp_client,
-                                  osc_send, osc_process)
-from osc4py3 import oscbuildparse
 from typing import Union
+
+from osc4py3 import oscbuildparse
+from osc4py3.as_eventloop import (
+    osc_startup, osc_udp_client, osc_send, osc_process
+)
 
 __all__ = ('Client', 'client', 'dirt')
 

--- a/sardine/io/Osc.py
+++ b/sardine/io/Osc.py
@@ -5,6 +5,9 @@ from osc4py3.as_eventloop import (osc_startup, osc_udp_client,
 from osc4py3 import oscbuildparse
 from typing import Union
 
+__all__ = ('Client', 'client', 'dirt')
+
+
 class Client:
 
     def __init__(self, ip: str = "127.0.0.1",

--- a/sardine/io/UserConfig.py
+++ b/sardine/io/UserConfig.py
@@ -6,6 +6,11 @@ from typing import Union
 from appdirs import *
 from rich import print
 
+__all__ = (
+    'Config', 'create_template_configuration_file',
+    'read_configuration_file', 'read_user_configuration'
+)
+
 
 @dataclass
 class Config:

--- a/sardine/io/__init__.py
+++ b/sardine/io/__init__.py
@@ -1,0 +1,4 @@
+from .MidiIo import *
+from .MidiListener import *
+from .Osc import *
+from .UserConfig import *

--- a/sardine/sequences/__init__.py
+++ b/sardine/sequences/__init__.py
@@ -1,0 +1,1 @@
+from .Sequence import *

--- a/sardine/superdirt/AutoBoot.py
+++ b/sardine/superdirt/AutoBoot.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
+from os import walk
 import pathlib
 import platform, threading, subprocess, os, signal
 from time import sleep
-from os import walk
-from rich import print
 from typing import Union
+
+from rich import print
 
 
 def find_startup_file():

--- a/sardine/superdirt/AutoBoot.py
+++ b/sardine/superdirt/AutoBoot.py
@@ -7,6 +7,8 @@ from typing import Union
 
 from rich import print
 
+__all__ = ('find_startup_file', 'find_synth_directory', 'SuperColliderProcess')
+
 
 def find_startup_file():
     """ Find the startup file when booting Sardine """

--- a/sardine/superdirt/SuperDirt.py
+++ b/sardine/superdirt/SuperDirt.py
@@ -3,10 +3,13 @@ import asyncio
 import functools
 from typing import TYPE_CHECKING, Union
 
-from ..io.Osc import dirt
+from ..io import dirt
 
 if TYPE_CHECKING:
-    from ..clock.Clock import Clock
+    from ..clock import Clock
+
+__all__ = ('SuperDirt',)
+
 
 class SuperDirt:
 

--- a/sardine/superdirt/__init__.py
+++ b/sardine/superdirt/__init__.py
@@ -1,0 +1,2 @@
+from .AutoBoot import *
+from .SuperDirt import *


### PR DESCRIPTION
To simplify cross-package import statements, this PR allows functions, classes, and objects to be imported from Sardine subpackages, specifically `clock`, `io`, `sequences`, and `superdirt`.

This also adds `__all__` variables to hide any imported functions in modules when using `from .mod import *`.