### PR TITLE
Limit the number of function states per runner

### DIFF
--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -1,13 +1,16 @@
 import asyncio
+from collections import deque
 from dataclasses import dataclass, field
+import functools
 from rich import print
 import inspect
 import traceback
 from typing import Any, Callable, TYPE_CHECKING, Union
 
-
 if TYPE_CHECKING:
     from .Clock import Clock
+
+MAX_FUNCTION_STATES = 3
 
 
 def _assert_function_signature(sig: inspect.Signature, args, kwargs):
@@ -67,7 +70,9 @@ class AsyncRunner:
 
     """
     clock: "Clock"
-    states: list[FunctionState] = field(default_factory=list)
+    states: list[FunctionState] = field(
+        default_factory=functools.partial(deque, (), MAX_FUNCTION_STATES)
+    )
 
     _swimming: bool = field(default=False, repr=False)
     _stop: bool = field(default=False, repr=False)


### PR DESCRIPTION
This limits the maximum number of function states that are tracked on each runner to reduce memory consumption over time.

Most often only 2 states are needed, since errors usually occur on the newest function only. However, it is possible for errors to propagate to older functions, such as using a wrong type on a global variable that was used across multiple function states. The current limit is arbitrarily set to 3, but may be increased if necessary.

https://github.com/Bubobubobubobubo/Sardine/blob/c72ccbef401986afcc443a40940ca7600713e932/sardine/clock/AsyncRunner.py#L13