### PR TITLE
Improve clock responsiveness and synchronization

### DIFF
--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -181,10 +181,12 @@ class AsyncRunner:
 
                 handle = self._wait_beats(delay)
                 reload = asyncio.create_task(self._reload_event.wait())
-                done, _ = await asyncio.wait((handle, reload), return_when=asyncio.FIRST_COMPLETED)
+                done, pending = await asyncio.wait((handle, reload), return_when=asyncio.FIRST_COMPLETED)
+
+                for fut in pending:
+                    fut.cancel()
                 if reload in done:
                     self._reload_event.clear()
-                    handle.cancel()
                     self.swim()
                     continue
 

--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -134,6 +134,7 @@ class AsyncRunner:
 
         """
         self._stop = True
+        self.reload()
 
     async def _runner(self):
         self.swim()

--- a/sardine/clock/AsyncRunner.py
+++ b/sardine/clock/AsyncRunner.py
@@ -79,7 +79,7 @@ class AsyncRunner:
     _swimming: bool = field(default=False, repr=False)
     _stop: bool = field(default=False, repr=False)
     _task: Union[asyncio.Task, None] = field(default=None, repr=False)
-    _reload_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _reload_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
 
     def push(self, func: Callable, *args, **kwargs):
         """Pushes a function state to the runner to be called in

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -14,9 +14,8 @@ from ..superdirt.SuperDirt import SuperDirt
 
 @functools.total_ordering
 class TickHandle:
-    __slots__ = ('when', 'fut')
-
     """A handle that allows waiting for a specific tick to pass in the clock."""
+    __slots__ = ('when', 'fut')
 
     def __init__(self, tick: int):
         self.when = tick

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -247,6 +247,7 @@ class Clock:
 
         runner.push(func, *args, **kwargs)
         if runner.started():
+            runner.reload()
             runner.swim()
         else:
             runner.start()

--- a/sardine/clock/Clock.py
+++ b/sardine/clock/Clock.py
@@ -38,6 +38,9 @@ class TickHandle:
             return NotImplemented
         return self.when == other.when and self.fut == other.fut
 
+    def __hash__(self):
+        return hash((self.when, self.fut))
+
     def __lt__(self, other):
         if not isinstance(other, TickHandle):
             return NotImplemented
@@ -204,6 +207,9 @@ class Clock:
     def _shift_handles(self, n_ticks: int):
         for handle in self.tick_handles:
             handle.when += n_ticks
+
+        for runner in self.runners.values():
+            runner.reload()
 
     def _update_handles(self):
         # this is implemented very similarly to asyncio.BaseEventLoop


### PR DESCRIPTION
This improves the responsiveness by allowing scheduled functions to immediately reload and/or recalculate their next beat when the user updates the function or changes the `bpm`, `ppqn`, or `accel`.

This also adds the ability to manually shift the clock's current tick for synchronization purposes:

```py
from sardine import *

c.tick -= 4           # Moves 4 ticks backwards
c.tick += c.ppqn * 3  # Moves 3 beats forwards
```

When the tick is updated this way, all functions are re-scheduled but sounds will play at their expected time (i.e. if a sound specifies `at=8`, it will still play 8 beats in the future, regardless of what the tick is set to in that time span).