### PR TITLE
Clock attributes are now sent in the basic OSC SuperDirt message

### DIFF
--- a/sardine/io/MIDISender.py
+++ b/sardine/io/MIDISender.py
@@ -99,6 +99,8 @@ class MIDISender:
             "note": self.note,
         }
 
+        i = int(i)
+
         def _message_without_iterator():
             """Compose a message if no iterator is given"""
 

--- a/sardine/io/OSCSender.py
+++ b/sardine/io/OSCSender.py
@@ -81,6 +81,8 @@ class OSCSender:
 
         final_message = {}
 
+        i = int(i)
+
         def _message_without_iterator():
             """Compose a message if no iterator is given"""
 

--- a/sardine/io/Osc.py
+++ b/sardine/io/Osc.py
@@ -71,14 +71,22 @@ class Client:
     ) -> None:
         async def _waiter():
             await handle
-            self._send(address, message)
+            self._send(clock, address, message)
 
         ticks = clock.get_beat_ticks(self.after, sync=False)
         handle = clock.wait_after(n_ticks=ticks)
         asyncio.create_task(_waiter(), name="osc-scheduler")
 
-    def _send(self, address: str, message):
+    def _send(self, clock: 'Clock', address: str, message):
         """Build user-made OSC messages"""
+        clock_information = [
+            'cps', (clock.tempo/60/4),
+            's_beat', clock.beat, 
+            's_bar', clock.bar, 
+            's_tick', clock.tick,
+            's_phase', clock.phase,
+            's_accel', clock.accel]
+        message.extend(clock_information)
         msg = oscbuildparse.OSCMessage(address, None, message)
         bun = oscbuildparse.OSCBundle(
             oscbuildparse.unixtime2timetag(time() + self._ahead_amount), [msg]

--- a/sardine/io/SuperDirtSender.py
+++ b/sardine/io/SuperDirtSender.py
@@ -70,11 +70,13 @@ class SuperDirtSender:
         handle = self.clock.wait_after(n_ticks=ticks)
         asyncio.create_task(_waiter(), name="superdirt-scheduler")
 
-    def out(self, i: Union[None, int] = None, orbit: int = 0) -> None:
+    def out(self, i: Union[None, int] = 0, orbit: int = 0) -> None:
         """
         Prototype for the Sender output.
         TODO: make the sample number patternable...
         """
+
+        i = int(i)
 
         if orbit != 0:
             self.content |= {"orbit": orbit}


### PR DESCRIPTION
- added `cps` for delay and temporal effects calculation.
- fixed a bug with i (iter) in some objects