### PR TITLE
cosmetic update on python-rtmidi build

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -199,4 +199,4 @@ Please provide feedback on the installation process! I try to document it as muc
 
 * **[WINDOWS ONLY]**: `uvloop` does not work on Windows. Fortunately, you can still run **Sardine** but don't expect the tempo/BPM to be accurate. You will have to drastically slow down the clock for it to work (~20bpm is a safe value)! This might be linked to a different implementation of `asyncio` on Windows.
 
-* **[LINUX/MACOS]**: `poetry install` fails on `python-rtmidi build`. Its probably because the `libjack-dev` lib is missing. You can install it with `sudo apt-get install libjack-dev` on Debian based systems, with `brew` for MacOS, and with `pacman` for any other Arch-based system.
+* **[LINUX/MACOS]**: `poetry install` fails on `python-rtmidi build`. Its probably because you missed libjack development files (`libjack-dev` or `libjack-jackd2-dev`). You can install it with `sudo apt-get install libjack-dev` on Debian based systems, with `brew` for MacOS, and with `pacman` for any other Arch-based system.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,7 +165,7 @@ Note that you can boot **Sardine** manually in a two-step process:
 
 1) `python3 -m asyncio`: start the asyncio REPL
 
-2) `from sardine import **`: import **Sardine** library
+2) `from sardine import *`: import **Sardine** library
 
 
 ### Code-editing


### PR DESCRIPTION
As it is explained inside istall instructions of python-rtmidi (https://spotlightkid.github.io/python-rtmidi/installation.html)

Linux
First you need a C++ compiler and the pthread library. Install the build-essential package on debian-based systems to get these.

Then you’ll need Python development headers and libraries. On debian-based systems, install the python-dev package. If you use the official installers from python.org you should already have these.

To get ALSA support, you must install development files for the libasound2 library (debian package: libasound2-dev). For JACK support, install the libjack development files (if you are using Jack1, install libjack-dev, if you are using Jack2, install libjack-jackd2-dev).