### PR TITLE
[grammar] new ramp syntax

### DIFF
--- a/sardine/sequences/LexerParser/grammars/proto.lark
+++ b/sardine/sequences/LexerParser/grammars/proto.lark
@@ -48,8 +48,8 @@ pattern: sum ("," sum?)* -> return_pattern
      | "T" "." "s"                                         -> get_second
      | "T" "." "µ"                                         -> get_microsecond // Unicode character U+00B5
      | "T" "." "μ"                                         -> get_microsecond // Unicode character U+03BC
-     | "{" sum "," sum "}"                                 -> generate_ramp
-     | "{" sum "," sum "," sum  "}"                        -> generate_ramp_with_range
+     | "[" sum ":" sum "]"                                 -> generate_ramp
+     | "[" sum ":" sum "," sum  "]"                        -> generate_ramp_with_range
      | "[" sum ("," sum)* ","? "]"                         -> make_list
      | SILENCE+                                            -> silence
      | "(" sum ")"
@@ -106,7 +106,7 @@ pattern: sum ("," sum?)* -> return_pattern
 ?note: note3                     -> finish_note
 
 ///////////////////////////////////////////////////////////////////////////////
-     
+
 // Tokens /////////////////////////////////////////////////////////////////////
 
 // Notes start with an uppercase letter, other names start with a lower case letter.

--- a/tests/test_pattern_parsing.py
+++ b/tests/test_pattern_parsing.py
@@ -220,6 +220,30 @@ class TestPatternParsing(unittest.TestCase):
                 result = parser.parse(pattern)
                 self.assertEqual(expected[i], result)
 
+    def test_ramps(self):
+        """
+        Test ramps with and without step
+        """
+        parser = PARSER
+        patterns = [
+            "[1:5]",
+            "[0:1,.3]",
+            "[10:8,.5]",
+            "0, [1:3], 4, 5"
+        ]
+        expected = [
+            [1, 2, 3, 4, 5],
+            [0, .3, .6, .9],
+            [10, 9.5, 9, 8.5, 8],
+            [0, 1, 2, 3, 4, 5]
+        ]
+        for i, pattern in enumerate(patterns):
+            with self.subTest(i=i, pattern=pattern):
+                result = parser.parse(pattern)
+                self.assertEqual(len(result), len(expected[i]))
+                for x, y in zip(result, expected[i]):
+                    self.assertAlmostEqual(x, y)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
see https://github.com/Bubobubobubobubo/sardine/issues/87

## Description

In this PR we introduce a new syntax for ramps in the pattern language: `[start:end]` and `[start:end,step]` instead of `{start,end}` and `{start,end,step}`.
This main advantage of this new syntax is to avoid using `{` and `}` in the grammar so we can apply Python formatting to patterns.