### PR TITLE
Use prebuilt wheels for LinkPython and python-rtmidi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 # Requirements: This is done differently by poetry!
 dependencies = [
     "Click>=8.1.3",
-    "LinkPython>=0.1",
+    "LinkPython-extern>=1.0.0",
     "python-rtmidi>=1.4.9",
     "inquirerpy>=0.3.4",
     "easing-functions>=1.0.4",


### PR DESCRIPTION
This updates sardine to source prebuilt wheels for the LinkPython dependency using my [LinkPython-extern][1] fork.

I've also uploaded prebuilt wheels for python-rtmidi on a [separate repository][2], which can be used with pip to include them when installing sardine with the following command:

```sh
pip install --find-links https://thegamecracks.github.io/python-rtmidi-wheels/ .
```

Unfortunately the choice to not create another package for python-rtmidi means that the regular `pip install .` command will not have access to the rtmidi prebuilt wheels.

## Draft status

This PR is pending an update to the documentation to describe the new installation instructions.

[1]: https://pypi.org/project/LinkPython-extern/
[2]: https://github.com/thegamecracks/python-rtmidi-wheels