### PR TITLE
Update dependencies to support Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 # Requirements: This is done differently by poetry!
 dependencies = [
     "Click>=8.1.3",
-    "LinkPython-extern>=1.0.0",
+    "LinkPython-extern>=1.0.1",
     "python-rtmidi>=1.4.9",
     "inquirerpy>=0.3.4",
     "easing-functions>=1.0.4",


### PR DESCRIPTION
LinkPython-extern 1.0.1 has newly released with support for 3.11. With this package updated, it will hopefully resolve the last pains with installing sardine for 3.11.