### PR TITLE
Fix regular install not copying fishery and sardine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
     "exceptiongroup>=1.0.4",
 ]
 
+[tool.hatch.build.targets.wheel]
+packages = ["fishery", "sardine"]
+
 [tool.hatch.version]
 path = "sardine/__init__.py"
 


### PR DESCRIPTION
Hatch was not properly configured to recognize which package directories were meant to be included with the installation, preventing non-editable (regular) installs from working correctly.
This is fixed by adding `fishery` and `sardine` to pyproject.toml as targets for wheels.