### PR TITLE
Correct license descriptions in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
     {name = "Raphaël Forment", email="raphael.forment@gmail.com"},
     {email = "raphael.forment@gmail.com"}
 ]
-license = {file = "LICENSE.txt"}
+license = "GPL-3.0-only"
+license-files = { paths = ["LICENSE.txt"] }
 readme = "README.md"
 requires-python = ">=3.10"
 


### PR DESCRIPTION
Updates the license metadata in accordance with [hatch docs][1] so `pip show sardine` doesn't dump the entirety of GPL-3.0 in its summary.

[1]: https://hatch.pypa.io/latest/config/metadata/#__tabbed_10_2