### PR TITLE
Increase error tolerance in get_beat_time()

### DIFF
--- a/sardine/base/clock.py
+++ b/sardine/base/clock.py
@@ -216,8 +216,12 @@ class BaseClock(BaseRunnerHandler, ABC):
 
         # Due to potential rounding errors, we might get a duration
         # that should be, but isn't actually equal to the interval.
-        # As such, we will replace any durations below a picosecond.
-        if math.isclose(duration, 0.0, rel_tol=0.0, abs_tol=1e-12):
+        # To mitigate this, we will replace any durations below 10
+        # microseconds.
+        # Rounding errors will worsen over time, but it is unlikely
+        # we'll get to a point where 10 microseconds is too little
+        # (but possible if sardine goes on for 5-6 years).
+        if math.isclose(duration, 0.0, rel_tol=0.0, abs_tol=1e-8):
             return interval
 
         return duration


### PR DESCRIPTION
This is mostly to mitigate the rapid iteration bug that might occur as a result of rounding errors. This issue was not noticed on Windows, but unix systems seem to have a habit of doing double iterations likely due to their more precise clocks.