### PR TITLE
[docs] syntax update after v0.2 rewrite

### DIFF
--- a/docs/documentation/reference.md
+++ b/docs/documentation/reference.md
@@ -45,7 +45,7 @@ th, td {
 }
 </style>
 
-## SuperDirt 
+## SuperDirt
 
 
 **SuperDirt** documentation is rather scarce and most of it needs to be inferred by looking at the source code. However, the behavior of most parameters is well known -- usually from experience -- by live coders. Moreover, **SuperDirt** can be customised freely to add custom effects and synthesizers. I'm working hard on gathering information about each and every parameter I can find :) Some of them are rather arcane. They are probably not meant to be used directly. Keep in mind that not all of them are useful and that you will likely find better options by building your own environment.
@@ -60,7 +60,7 @@ th, td {
 |**`midinote`**     |Pitch around given MIDI note                                |0 - 127       |
 |**`note`**         |Pitch around given note                                     |???           |
 |**`octave`**       |Pitch up or down depending on octave number                 |0 -> x        |
-|**`sound`**        |**Implicit** (first argument of `S()`)                      |--------------|
+|**`sound`**        |**Implicit** (first argument of `D()`)                      |--------------|
 |**`begin`**        |Start position of audio playback                            |0 -> 1        |
 |**`end`**          |End position of audio playback                              |0 -> 1        |
 |**`speed`**        |Sample playback, impacts pitch. Negative will play reverse  |-x -> 0 -> x  |
@@ -89,13 +89,13 @@ th, td {
 |**`dry`**          |Dry/Wet balance                                             |0 -> 1        |
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('hh', amp=1, 
-            room='s($.S)', 
-            dry=0.1, 
-            size='s($)').out()
-    a(test_fx, d=0.25)
+@swim
+def test_fx(p=0.25):
+    D('hh', amp=1,
+            room='s($.S)',
+            dry=0.1,
+            size='s($)')
+    a(test_fx, p=0.25)
 ```
 
 ##### Delay
@@ -110,14 +110,14 @@ The `delay` effect is initially built for Tidal, which is based on a cyclical ti
 
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('hh', 
-            speed='1|2|4',
+@swim
+def test_fx(p=0.25):
+    D('hh',
+            speep='1|2|4',
             delay=1/2, delaytime=1/(2/3),
             delayfeedback='0.5+(r/4)',
-            amp=1).out() 
-    a(test_fx, d=0.25)
+            amp=1)
+    a(test_fx, p=0.25)
 ```
 
 ##### Phaser
@@ -130,13 +130,13 @@ Not functioning as it should?
 |**`phaserdepth`**  |Modulation amount                                           |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('jvbass', 
+@swim
+def test_fx(p=0.25):
+    D('jvbass',
             midinote='C|Eb|G|Bb',
-            phaserrate='1:10', 
-            phaserdepth='s($*2)', amp=1).out() 
-    a(test_fx, d=0.5)
+            phaserrate='1:10',
+            phaserdepth='s($*2)', amp=1)
+    a(test_fx, p=0.5)
 ```
 
 ##### Leslie
@@ -151,11 +151,11 @@ This is a simple emulation of a Leslie rotating speaker typically used in music 
 |**`lsize`**        |Wooden cabinet size (in meters)                             |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('jvbass', amp=1, leslie=0.9,
-            lrate=0.1, lsize='0.1+r*2').out()
-    a(test_fx, d=0.25)
+@swim
+def test_fx(p=0.25):
+    D('jvbass', amp=1, leslie=0.9,
+            lrate=0.1, lsize='0.1+r*2')
+    a(test_fx, p=0.25)
 ```
 
 ##### Tremolo
@@ -169,12 +169,13 @@ A simple tremolo effect.
 
 
 ```python
-@swim 
-def test_fx(d=0.25, i=0):
-    S('amencutup:[1:20]', 
+@swim
+def test_fx(p=0.25, i=0):
+    D('amencutup:[1:20]',
             tremolorate='16|32',
-            tremolodepth='[0:1,0.25]').out(i)
-    a(test_fx, d=0.5, i=i+1)
+            tremolodepth='[0:1,0.25]',
+            i=i)
+    a(test_fx, p=0.5, i=i+1)
 ```
 
 ##### Granular weirdness
@@ -187,12 +188,13 @@ This is a weird granular effect probably intended to serve as a building block f
 |**`psdisp`**       |Pitch-shift dispersion                                      |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25, i=0):
-    S('amencutup:[1:20]', 
+@swim
+def test_fx(p=0.25, i=0):
+    D('amencutup:[1:20]',
             psrate='2',
-            psdisp='[0:1,0.5]').out(i)
-    a(test_fx, d=0.5, i=i+1)
+            psdisp='[0:1,0.5]',
+            i=i)
+    a(test_fx, p=0.5, i=i+1)
 ```
 
 #### Filters
@@ -206,12 +208,12 @@ def test_fx(d=0.25, i=0):
 |**`bandqf`**       |Bandpass resonance                                          |0 -> x             |
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('jvbass', 
+@swim
+def test_fx(p=0.25):
+    D('jvbass',
             midinote='C.|C|Eb|G|Bb',
-            cutoff='r*7000', resonance='r/2', amp=1).out() 
-    a(test_fx, d=0.5)
+            cutoff='r*7000', resonance='r/2', amp=1)
+    a(test_fx, p=0.5)
 ```
 
 #### Distortion
@@ -226,12 +228,12 @@ Will distort your signal, combination of multiple effects put together. It works
 
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('tabla:r*200', cut=1, 
+@swim
+def test_fx(p=0.25):
+    D('tabla:r*200', cut=1,
             squiz='0|2|4|8',
-            midinote='C|F|Bb|E5b', amp=1).out() 
-    a(test_fx, d=0.5)
+            midinote='C|F|Bb|E5b', amp=1)
+    a(test_fx, p=0.5)
 ```
 
 ##### Triode
@@ -243,15 +245,15 @@ Very gentle distortion. I actually have no idea about how the `triode` parameter
 |**`triode`**       |Distortion amount                                           |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('tabla:r*200', cut=1, 
+@swim
+def test_fx(p=0.25):
+    D('tabla:r*200', cut=1,
             triode='r', # comment me
-            midinote='C|F|Bb|E5b', amp=1).out() 
-    a(test_fx, d=0.5)
+            midinote='C|F|Bb|E5b', amp=1)
+    a(test_fx, p=0.5)
 ```
 
-##### Distort 
+##### Distort
 
 Heavy distortion that will/can wildly change the spectrum of your sound.
 
@@ -260,15 +262,15 @@ Heavy distortion that will/can wildly change the spectrum of your sound.
 |**`distort`**      |Distortion amount                                           |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25):
-    S('sd:r*200', cut=1, 
+@swim
+def test_fx(p=0.25):
+    D('sd:r*200', cut=1,
             distort='0|0.5',
-            midinote='C|G', amp=1).out() 
-    a(test_fx, d=0.5)
+            midinote='C|G', amp=1)
+    a(test_fx, p=0.5)
 ```
 
-##### Shaping 
+##### Shaping
 
 Shape is an amplifier that can enter distortion territory but with a gentle curve. It will naturally
 make your sound louder the more you ramp up the value.
@@ -278,10 +280,10 @@ make your sound louder the more you ramp up the value.
 |**`shape`**        |Amplification amount                                        |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25, i=0):
-    S('amencutup:[1:20]', shape='[0:1,0.1]').out(i)
-    a(test_fx, d=0.5, i=i+1)
+@swim
+def test_fx(p=0.25, i=0):
+    D('amencutup:[1:20]', shape='[0:1,0.1]', i=i)
+    a(test_fx, p=0.5, i=i+1)
 ```
 ##### Crush
 
@@ -292,10 +294,10 @@ A very agressive bit crushing effect. Works only when you input multiples of 2. 
 |**`crush`**        |Crushing factor                                             |0 -> x        |
 
 ```python
-@swim 
-def test_fx(d=0.25, i=0):
-    S('bd, sn, hh, sn', crush=4).out(i)
-    a(test_fx, d=0.5, i=i+1)
+@swim
+def test_fx(p=0.25, i=0):
+    D('bd, sn, hh, sn', crush=4, i=i)
+    a(test_fx, p=0.5, i=i+1)
 ```
 
 ##### Ring Modulation

--- a/docs/documentation/sardinopedia/basic_swimming_lessons.md
+++ b/docs/documentation/sardinopedia/basic_swimming_lessons.md
@@ -10,7 +10,7 @@ Joking aside, and for those of you who already know how to program, *swimming fu
 S('bd').out()
 ```
 
-This command will play a single bassdrum with the **SuperDirt** sound engine. We are not currently using a *swimming function*, this event is atomic and non-repeating. It is a one-shot event, a single instruction sent to the **Python** interpreter. We haven't learned anything yet, you don't know anything about **Senders**, *swimming functions*, etc... Just note that these one-letter objects are constantly and repeatedly used to trigger different types of messages. We will need to *pattern* them and to *arrange* or *compose* them in time. You can use **Sender** objects outside of a recursive function. It will work, but you will be *un-timed*, or *out-of-time*, just like your regular **Python** script that doesn't really care about time or about when or how things happen. 
+This command will play a single bassdrum with the **SuperDirt** sound engine. We are not currently using a *swimming function*, this event is atomic and non-repeating. It is a one-shot event, a single instruction sent to the **Python** interpreter. We haven't learned anything yet, you don't know anything about **Senders**, *swimming functions*, etc... Just note that these one-letter objects are constantly and repeatedly used to trigger different types of messages. We will need to *pattern* them and to *arrange* or *compose* them in time. You can use **Sender** objects outside of a recursive function. It will work, but you will be *un-timed*, or *out-of-time*, just like your regular **Python** script that doesn't really care about time or about when or how things happen.
 
 By using **Python** with **Sardine**, you will constantly run into things that either are *timed* or *un-timed*. It can help if you like manipulating only certain parts of your interactive programs with time constraints or if you like to store options and configuration in a part of your script, apart from your musical patterns.
 
@@ -22,9 +22,9 @@ def basic():
     print('I am swimming now!')
     again(basic)
 
-hush(basic) # or panic()
+silence(basic) # or panic()
 ```
-This is the most basic and iconic *swimming function* you can write. We could make a sweatshirt out of it. It is just like your regular **Python** function to the exception of two little details : 
+This is the most basic and iconic *swimming function* you can write. We could make a sweatshirt out of it. It is just like your regular **Python** function to the exception of two little details :
 
 - the `@swim` or `@die` decorators.
 
@@ -32,18 +32,18 @@ This is the most basic and iconic *swimming function* you can write. We could ma
 
 Behind the stage, the `@swim` decorator will provide all the necessary plumbing to properly handle time and repetition. The `again(...)` function is actually the same thing as `@swim`. It is how the recursion happens, where the function enters the infinite time loop defined by the clock. Updating the function with the `@die` decorator will stop the recursivity, ending the production of sound.
 
-Using `hush(function_name)` or just `hush()` will halt the function execution. There is also `panic()` which is a bit more extreme but needed in some cases where sound doesn't stop after running `hush()`. `hush()` will just stop the function / all functions while `panic()` will do the same but also violently stop every sound sample / synthesizer currently being used. This is useful if you feel that you are loosing control when playing with loud or very long samples.
+Using `silence(function_name)` or just `silence()` will halt the function execution. There is also `panic()` which is a bit more extreme but needed in some cases where sound doesn't stop after running `silence()`. `silence()` will just stop the function / all functions while `panic()` will do the same but also violently stop every sound sample / synthesizer currently being used. This is useful if you feel that you are loosing control when playing with loud or very long samples.
 
 
 ### Swimming with style
 
 ```python3
-@swim 
+@swim
 def basic(d=0.5, i=0):
     print('I am swimming now!')
     again(basic, d=0.5, i=i+1)
 
-hush(basic)
+silence(basic)
 ```
 
 This is a *swimming function* with some minor improvements. The function is passed a duration (`d`) and an iterator (`i`) as arguments. This is the function you will want/need to save as a snippet somewhere in your text editor. **Sardine** users write this skeleton constantly, mechanically, without even thinking about it.
@@ -55,28 +55,28 @@ This is a *swimming function* with some minor improvements. The function is pass
 ### Drowning in numbers
 
 ```python3
-@swim 
+@swim
 def basic(d=0.5, i=0, j=0, k=0):
     print(f'I am swimming with {i}, {j}, and {k}!')
     again(basic, d=0.5, i=i+1, j=j+2, k=P('r*10', i))
 
-hush(basic)
+silence(basic)
 ```
 
 A function with three different iterators. Why not? Notice how the iterator values are evolving independently. `i` is a basic increment, while `j` walks through even numbers. And `k` is randomized using the notation `P('r*10', i)`. To learn more about this, please refer to the section about Patterns and about the pattern Language. You will sometimes encounter features you don't know about yet while scrolling through these examples. Don't worry, they are covered somewhere!
- 
+
 ### Swimming with friends
 
 ```python3
 def calling_you():
     print('I hear you')
 
-@swim 
+@swim
 def basic():
     calling_you()
     again(basic)
 
-hush(basic)
+silence(basic)
 ```
 A swimming function can call a regular function (*i.e.* a function with no **Sardine** decorator). This example is boring as hell but it demonstrates one thing: **Sardine** is just regular **Python** with a twist. Be creative, import your favorite packages and make your computer crash in rhythm!
 
@@ -114,9 +114,9 @@ Exchanging data between *swimming functions* just like sardines playing waterpol
 
 ## II - Surfing: concise syntax
 
-There is an alternative jam-oriented way of using *swimming functions* inspired by [FoxDot](https://foxdot.org/), another very cool *live-coding* library for **Python** created by [Ryan Kirkbride](https://ryan-kirkbride.github.io/). This technique is an *emulation* or *simulation* of **FoxDot** mode of operation. It uses the same syntax and the same philosophy of patterning but it relies on **Sardine**'s foundations. This mode of *swimming* is basically assigning **Senders** to an invisible *swimming function* that runs automatically behind your back. 
+There is an alternative jam-oriented way of using *swimming functions* inspired by [FoxDot](https://foxdot.org/), another very cool *live-coding* library for **Python** created by [Ryan Kirkbride](https://ryan-kirkbride.github.io/). This technique is an *emulation* or *simulation* of **FoxDot** mode of operation. It uses the same syntax and the same philosophy of patterning but it relies on **Sardine**'s foundations. This mode of *swimming* is basically assigning **Senders** to an invisible *swimming function* that runs automatically behind your back.
 
-!!! warning 
+!!! warning
 
     If you don't know yet what a **Sender** is, you better go consult the page about it first before reading this section.
 
@@ -127,7 +127,7 @@ By default, there are 48 `Players` ready for surfing. This is more than you will
 * `Pa.rate`: time spent on a single event in a linear sequence of events (step speed).
 * `Pa.dur`: duration of a single event in a linear sequence of events (step duration).
 
-While playing/patterning with *surfboards*, you will only ever need to deal with these three methods. All the rest is integrated with the rest of the **Sardine** ecosystem: 
+While playing/patterning with *surfboards*, you will only ever need to deal with these three methods. All the rest is integrated with the rest of the **Sardine** ecosystem:
 
 ```python
 # The sun is high, let's go surfing
@@ -135,7 +135,7 @@ Pa >> play('bd, ., hh')
 Pa.rate = 1
 
 # Ok, I'm done surfing for today.. Time to eat marshmallows..
-hush()
+silence()
 ```
 
 In addition to that, take note of the `play()` method used for assigning a **Sender** to **Players**. There is one method per available default **Sender**. It behaves **exactly like your typical senders**:
@@ -151,7 +151,7 @@ I repeat, these functions are basically senders with a different name! You will 
 
 ```python
 PB >> play('jvbass:r*8, ..., pluck, ...')
-PA >> play('bd, ., hh, sn, hh', 
+PA >> play('bd, ., hh, sn, hh',
         amp=0.4,
         legato='0.3~1', speed='1')
 ```
@@ -169,7 +169,7 @@ The `play_midi()` function is the good old `M()` **Sender**. The `note=` paramet
 
 ### How to stop surfing
 
-**Surfing** patterns are fully integrated with the rest of **Sardine**. You can shut them down by calling the `hush()` or `panic()` function just like for other *swimming functions*. You can also use direct the Player value to "None" (PB >> None). This will stop the output for that player - which is useful if you have multiple Players. To start again, just load the PB >> play() line again. 
+**Surfing** patterns are fully integrated with the rest of **Sardine**. You can shut them down by calling the `silence()` or `panic()` function just like for other *swimming functions*. You can also use direct the Player value to "None" (PB >> None). This will stop the output for that player - which is useful if you have multiple Players. To start again, just load the PB >> play() line again.
 ```python
 PA >> play('bd, ., hhh, .')
 PA.rate = 1
@@ -179,7 +179,7 @@ PB.dur = 0.5
 
 PB >> None # stops only the PB Player
 
-hush() # stops all Players
+silence() # stops all Players
 ```
 
 
@@ -191,28 +191,28 @@ This section requires a good understanding of general **Sardine** concepts. You 
 
 ```python
 
-@swim 
+@swim
 def fast(d=0.25, i=0):
     S('bd', speed='0.5,2', legato=0.1).out(i, div=4, rate=2)
-    S('hh, jvbass:0|8|4,', 
+    S('hh, jvbass:0|8|4,',
             pan='[0:1,0.1]',
             legato=0.1).out(i, div=8 if rarely()
                     else 5, rate=2)
     S('cp', legato=0.1).out(i, div=8)
     a(fast, d=1/8, i=i+1)
 ```
-**Sardine** *swimming functions* are usually slow (compared to the clock internal speed). However, you can speed up your recursion, the only hard limit being the speed at which the clock itself operates. It means that the faster you go, the better the rhythmic precision. The faster, the merrier! You will be able to have a finely grained control over time and events, with the ability to write more groovy or swinging code. It will also make your LFOs and signal-like patterns sing more. 
+**Sardine** *swimming functions* are usually slow (compared to the clock internal speed). However, you can speed up your recursion, the only hard limit being the speed at which the clock itself operates. It means that the faster you go, the better the rhythmic precision. The faster, the merrier! You will be able to have a finely grained control over time and events, with the ability to write more groovy or swinging code. It will also make your LFOs and signal-like patterns sing more.
 
 The recipe for *fast swimming* is the following:
 
 - Use a very fast recursion speed (`1/8`, `1/16`, `1/32`), usually constant (no patterning).
 
-- Play a lot with silences and with the arguments of `.out(iterator, div, rate)`. 
+- Play a lot with silences and with the arguments of `.out(iterator, div, rate)`.
 
 ### Fast swimming template
 
 ```python
-@swim 
+@swim
 def fast(d=0.5, i=0):
     # print("Damn, that's fast!")
     a(fast, d=1/32, i=i+1)
@@ -223,7 +223,7 @@ This is the template for a fast *swimming function*. You can skip the iterator i
 
 ```python
 
-@swim 
+@swim
 def fast(d=0.5, i=0):
     S('bd').out(i, div=8)
     a(fast, d=1/16, i=i+1)
@@ -239,7 +239,7 @@ The `.out()` method as well as the independant `P()` [object](#patterning-freely
 Let's illustrate. In the example below, we are playing with various divisors to generate an interesting rythmic pattern. Combine that with more interesting drumming and boom, you now have the secret recipe for an interesting [algorave](https://algorave.com/).
 
 ```python
-@swim 
+@swim
 def fast(d=0.5, i=0):
     S('bd').out(i, div=8)
     S('hh').out(i, div=7)
@@ -253,10 +253,10 @@ Of course we can. So far, we only used one patterning speed because every **send
 
 ```python
 c.bpm = 125
-@swim 
+@swim
 def there_is_a_light(d=0.5, i=0):
     S('drum', legato=1, speed='1').out(i, 8)
-    S('drum:[1,2,3,4]', legato=1, 
+    S('drum:[1,2,3,4]', legato=1,
         speed=P('1,2,3,4,5,1!2,4!4', i+1, 2, 0.5)).out(i, 4)
     a(there_is_a_light, d=1/8, i=i+1)
 ```

--- a/docs/documentation/sardinopedia/basic_swimming_lessons.md
+++ b/docs/documentation/sardinopedia/basic_swimming_lessons.md
@@ -7,7 +7,7 @@ Joking aside, and for those of you who already know how to program, *swimming fu
 ### Out-of-time
 
 ```python3
-S('bd').out()
+D('bd')
 ```
 
 This command will play a single bassdrum with the **SuperDirt** sound engine. We are not currently using a *swimming function*, this event is atomic and non-repeating. It is a one-shot event, a single instruction sent to the **Python** interpreter. We haven't learned anything yet, you don't know anything about **Senders**, *swimming functions*, etc... Just note that these one-letter objects are constantly and repeatedly used to trigger different types of messages. We will need to *pattern* them and to *arrange* or *compose* them in time. You can use **Sender** objects outside of a recursive function. It will work, but you will be *un-timed*, or *out-of-time*, just like your regular **Python** script that doesn't really care about time or about when or how things happen.
@@ -39,16 +39,16 @@ Using `silence(function_name)` or just `silence()` will halt the function execut
 
 ```python3
 @swim
-def basic(d=0.5, i=0):
+def basic(p=0.5, i=0):
     print('I am swimming now!')
-    again(basic, d=0.5, i=i+1)
+    again(basic, p=0.5, i=i+1)
 
 silence(basic)
 ```
 
-This is a *swimming function* with some minor improvements. The function is passed a duration (`d`) and an iterator (`i`) as arguments. This is the function you will want/need to save as a snippet somewhere in your text editor. **Sardine** users write this skeleton constantly, mechanically, without even thinking about it.
+This is a *swimming function* with some minor improvements. The function is passed a period (`p`) and an iterator (`i`) as arguments. This is the function you will want/need to save as a snippet somewhere in your text editor. **Sardine** users write this skeleton constantly, mechanically, without even thinking about it.
 
-- The `d` parameter is the function's **duration**,  the `0.5` value representing half of a beat.  
+- The `p` parameter is the function's **period**,  the `0.5` value representing half of a beat.  
 
 - The `i` parameter is an hand-crafted **iterator**, progressively incremented by recursion. Don't be scared by all this jargon. It just means that the value increases by one each time the function is repeated.
 
@@ -56,9 +56,9 @@ This is a *swimming function* with some minor improvements. The function is pass
 
 ```python3
 @swim
-def basic(d=0.5, i=0, j=0, k=0):
+def basic(p=0.5, i=0, j=0, k=0):
     print(f'I am swimming with {i}, {j}, and {k}!')
-    again(basic, d=0.5, i=i+1, j=j+2, k=P('r*10', i))
+    again(basic, p=0.5, i=i+1, j=j+2, k=P('r*10', i))
 
 silence(basic)
 ```
@@ -97,18 +97,18 @@ A *swimming function* calling another one, which will call back the first one in
 
 ```python3
 @swim
-def first(d=0.5, rng=0):
+def first(p=0.5, rng=0):
     print(f"Received: {rng}")
     rng = randint(1,10)
     print(f"Sending: {rng}")
-    again(second, d=0.5, rng=rng)
+    again(second, p=0.5, rng=rng)
 
 # evaluate me first
-def second(d=0.5, rng=0):
+def second(p=0.5, rng=0):
     print(f"Received: {rng}")
     rng = randint(1,10)
     print(f"Sending: {rng}")
-    again(first, d=0.5, rng=rng)
+    again(first, p=0.5, rng=rng)
 ```
 Exchanging data between *swimming functions* just like sardines playing waterpolo. This is just an extension of some on the materials depicted above. There is no limit to the things you can do by recursion. It will only gradually cause more headaches as you go along.
 
@@ -160,9 +160,9 @@ By using the `play()` method and combining it with regular patterns, you can mor
 ### Surfing on MIDI Cables
 
 ```python
-PA >> play_midi('<C@maj7>', dur='1~8')
+PA >> play_midi('<C@maj7>', period='1~8')
 PA.dur = 3
-PB >> play_midi("C.., C|C'|C''", dur='1~8')
+PB >> play_midi("C.., C|C'|C''", period='1~8')
 PB.rate = 2
 ```
 The `play_midi()` function is the good old `M()` **Sender**. The `note=` parameter has been promoted to an *arg* in this mode in order to save you from having to type 5 more letters :)
@@ -175,7 +175,7 @@ PA >> play('bd, ., hhh, .')
 PA.rate = 1
 
 PB >> play('cp')
-PB.dur = 0.5
+PB.period = 0.5
 
 PB >> None # stops only the PB Player
 
@@ -192,14 +192,16 @@ This section requires a good understanding of general **Sardine** concepts. You 
 ```python
 
 @swim
-def fast(d=0.25, i=0):
-    S('bd', speed='0.5,2', legato=0.1).out(i, div=4, rate=2)
-    S('hh, jvbass:0|8|4,',
+def fast(p=0.25, i=0):
+    D('bd', speed='0.5,2', legato=0.1, i=i, d=4, rate=2)
+    D('hh, jvbass:0|8|4,',
             pan='[0:1,0.1]',
-            legato=0.1).out(i, div=8 if rarely()
-                    else 5, rate=2)
-    S('cp', legato=0.1).out(i, div=8)
-    a(fast, d=1/8, i=i+1)
+            legato=0.1,
+            i=i,
+            d=8 if rarely() else 5,
+            rate=2)
+    D('cp', legato=0.1, i=I, d=8)
+    a(fast, p=1/8, i=i+1)
 ```
 **Sardine** *swimming functions* are usually slow (compared to the clock internal speed). However, you can speed up your recursion, the only hard limit being the speed at which the clock itself operates. It means that the faster you go, the better the rhythmic precision. The faster, the merrier! You will be able to have a finely grained control over time and events, with the ability to write more groovy or swinging code. It will also make your LFOs and signal-like patterns sing more.
 
@@ -207,15 +209,15 @@ The recipe for *fast swimming* is the following:
 
 - Use a very fast recursion speed (`1/8`, `1/16`, `1/32`), usually constant (no patterning).
 
-- Play a lot with silences and with the arguments of `.out(iterator, div, rate)`.
+- Play a lot with silences and with the arguments `iterator, div, rate`.
 
 ### Fast swimming template
 
 ```python
 @swim
-def fast(d=0.5, i=0):
+def fast(p=0.5, i=0):
     # print("Damn, that's fast!")
-    a(fast, d=1/32, i=i+1)
+    a(fast, p=1/32, i=i+1)
 ```
 This is the template for a fast *swimming function*. You can skip the iterator if you don't need it or if you wish to use another iteration tool (such as **amphibian variables**). This function is really fast. Uncomment the `print` statement to notice how fast it is. To learn how to control it efficiently, take a look at the following paragraphs about *divisors* and the *rate* factor.
 
@@ -224,15 +226,15 @@ This is the template for a fast *swimming function*. You can skip the iterator i
 ```python
 
 @swim
-def fast(d=0.5, i=0):
-    S('bd').out(i, div=8)
-    a(fast, d=1/16, i=i+1)
+def fast(p=0.5, i=0):
+    D('bd', i=i, d=8)
+    a(fast, p=1/16, i=i+1)
 ```
-The `.out()` method as well as the independant `P()` [object](#patterning-freely-p) can take up to three arguments:
+The `D()` [object](#patterning-freely-p) can take up to three arguments:
 
 - `i` (*int*): the iterator for patterning. **Mandatory** for the two other arguments to work properly. This **iterator** is the index of the values extracted from your linear list-like patterns. How this index will be interpreted will depend on the next two arguments.
 
-- `div` (*int*): **a timing divisor**. It is very much alike a modulo operation. If `div=4`, the event will hit once every 4 iterations. The default is `div=1`, where every event is a hit! Be careful not to set a `div=1` on a very fast *swimming function* as it could result in catastrophic failure / horrible noises. There is no parachute out in the open sea.
+- `d` (*int*): **a timing divisor**. It is very much alike a modulo operation. If `d=4`, the event will hit once every 4 iterations. The default is `d=1`, where every event is a hit! Be careful not to set a `d=1` on a very fast *swimming function* as it could result in catastrophic failure / horrible noises. There is no parachute out in the open sea.
 
 - `rate` (*float*): a speed factor for iterating over pattern values. It will slow down or speed up the iteration speed, the speed at which the pattern values are indexed on. For the pattern `1, 2, 3` and a rate of `0.5`, the result will be perceptually similar to `1, 1, 2, 2, 3, 3`.
 
@@ -240,11 +242,11 @@ Let's illustrate. In the example below, we are playing with various divisors to 
 
 ```python
 @swim
-def fast(d=0.5, i=0):
-    S('bd').out(i, div=8)
-    S('hh').out(i, div=7)
-    S('sd').out(i, div=16)
-    a(fast, d=1/16, i=i+1)
+def fast(p=0.5, i=0):
+    D('bd', i=i, d=8)
+    D('hh', i=i, d=7)
+    D('sd', i=i, d=16)
+    a(fast, p=1/16, i=i+1)
 ```
 
 ### Can we do more?
@@ -254,11 +256,12 @@ Of course we can. So far, we only used one patterning speed because every **send
 ```python
 c.bpm = 125
 @swim
-def there_is_a_light(d=0.5, i=0):
-    S('drum', legato=1, speed='1').out(i, 8)
-    S('drum:[1,2,3,4]', legato=1,
-        speed=P('1,2,3,4,5,1!2,4!4', i+1, 2, 0.5)).out(i, 4)
-    a(there_is_a_light, d=1/8, i=i+1)
+def there_is_a_light(p=0.5, i=0):
+    D('drum', legato=1, speed='1', i=i, d=8)
+    D('drum:[1,2,3,4]', legato=1,
+        speed=P('1,2,3,4,5,1!2,4!4', i+1, 2, 0.5),
+        i=i, d=8)
+    a(there_is_a_light, p=1/8, i=i+1)
 ```
 Go slow, read line after line and you will eventually get it!
 
@@ -273,15 +276,15 @@ Take a *swimming function*, make it long enough, use our very special `sleep()` 
 
 ```python
 @swim
-def sonorous_cake(d=0.5, i=0):
-    S('bd').out()
+def sonorous_cake(p=0.5, i=0):
+    D('bd')
     sleep(0.5)
-    S('hh').out()
+    D('hh')
     sleep(0.5)
-    S('bd').out()
+    D('bd')
     sleep(0.5)
-    S('sn').out()
-    a(sonorous_cake, d=2, i=i+1)
+    D('sn')
+    a(sonorous_cake, p=2, i=i+1)
 ```
 
 ### Declarative style
@@ -289,7 +292,7 @@ def sonorous_cake(d=0.5, i=0):
 Make your *swimming functions* very dense, write using a mostly declarative style. Spice it up with the patterning system if you'd like:
 ```python
 @swim
-def one_line(d=0.5, i=0):
-    S('bd, drum, sn, drum:2').out(i)
-    a(one_line, d=0.5, i=i+1)
+def one_line(p=0.5, i=0):
+    D('bd, drum, sn, drum:2', i=i)
+    a(one_line, p=0.5, i=i+1)
 ```

--- a/docs/documentation/sardinopedia/basic_swimming_lessons.md
+++ b/docs/documentation/sardinopedia/basic_swimming_lessons.md
@@ -209,7 +209,7 @@ The recipe for *fast swimming* is the following:
 
 - Use a very fast recursion speed (`1/8`, `1/16`, `1/32`), usually constant (no patterning).
 
-- Play a lot with silences and with the arguments `iterator, div, rate`.
+- Play a lot with silences and with the arguments `iterator, divisor, rate`.
 
 ### Fast swimming template
 

--- a/docs/documentation/sardinopedia/melody.md
+++ b/docs/documentation/sardinopedia/melody.md
@@ -4,9 +4,9 @@
 
 ```python3
 @swim
-def hh(d=0.5, i=0):
-    S('hh', speed='[1:8]').out(i)
-    again(hh, d=0.5, i=i+1)
+def hh(p=0.5, i=0):
+    D('hh', speep='[1:8]', i=i)
+    again(hh, p=0.5, i=i+1)
 ```
 Changing the speed of audio playback for a given audio sample. Cheap version of tuning.
 
@@ -14,9 +14,9 @@ Changing the speed of audio playback for a given audio sample. Cheap version of 
 
 ```python3
 @swim
-def hh(d=0.5, i=0):
-    S('hh', midinote='C5!3, E5, G5').out(i)
-    again(hh, d=0.5, i=i+1)
+def hh(p=0.5, i=0):
+    D('hh', midinote='C5!3, E5, G5', i=i)
+    again(hh, p=0.5, i=i+1)
 ```
 Pitching an audio sample relatively to a MIDI note.
 
@@ -24,10 +24,8 @@ Pitching an audio sample relatively to a MIDI note.
 
 ```python3
 @swim
-def hh(d=0.5, i=0):
-    S('hh', freq='100 + (r*2000)').out(i)
-    again(hh, d=0.5, i=i+1)
+def hh(p=0.5, i=0):
+    D('hh', freq='100 + (r*2000)', i=i)
+    again(hh, p=0.5, i=i+1)
 ```
 Pitching an audio sample relatively to a given frequency (in `hertz`).
-
-

--- a/docs/documentation/sardinopedia/pattern_language.md
+++ b/docs/documentation/sardinopedia/pattern_language.md
@@ -10,25 +10,25 @@ I am not very skilled at developing custom programming languages but the plan.. 
 
 ```python3
 @swim
-def number(d=0.5, i=0):
+def number(p=0.5, i=0):
     print(P('1, 1+1, 1*2, 1/3, 1%4, 1+(2+(5/2))', i))
-    again(number, d=0.5, i=i+1)
+    again(number, p=0.5, i=i+1)
 ```
 
 You can write numbers (both *integers* and *floating point numbers*) and use common operators such as **addition**, **substraction**, **division**, **multiplication**, **modulo**, etc... For precision in your calculations, you can of course resort to using parentheses. By default, **Sardine** is made so that most arithmetic operators can be used on almost anything, expect if intuitively it doesn't make sense at all like multiplying a string against a string.
 
 **Let's stop for a moment and try to remember the following**: you can apply arithmetics to numbers but also to lists! You can for instance write an addition between a number and a list, between two lists, between a number and a note, between a chord and a list, etc.. All of this is supported by the language. Incidentally, it means that functions that work on lists can also work on single tokens. It also means that functions that are supposed to work for single numbers will work for lists, because the function will be mapped to every element in the list. It turns the act of composing patterns into a rather organic process.
 
-#### a1) Time-dependant numbers 
+#### a1) Time-dependant numbers
 
 ```python3
 @swim
-def number(d=0.5, i=0):
+def number(p=0.5, i=0):
     print(P('$, r, m, p', i))
-    again(number, d=0.5, i=i+1)
+    again(number, p=0.5, i=i+1)
 ```
 
-Some number tokens are clock-time dependant (based on **Sardine** clock time) and refer to a moment in time. Depending on the moment your recursion takes place, you might see some values recurring because you are not polling continuously but polling just a tiny and predictible moment in time. 
+Some number tokens are clock-time dependant (based on **Sardine** clock time) and refer to a moment in time. Depending on the moment your recursion takes place, you might see some values recurring because you are not polling continuously but polling just a tiny and predictible moment in time.
 
 - `$`: **tick**, the tick number since the clock started.
 - `$.p`: **phase**, a number between `0` and your `c.ppqn`.
@@ -37,18 +37,18 @@ Some number tokens are clock-time dependant (based on **Sardine** clock time) an
 
 ```python3
 @swim
-def number(d=0.5, i=0):
+def number(p=0.5, i=0):
     print(P('$, $.m, $.p')).out(i)
-    again(number, d=0.5, i=i+1)
+    again(number, p=0.5, i=i+1)
 ```
 
 Some other number tokens are absolute-time dependant. They are mostly used for long-running sequences and/or for introducing a random factor in the result of the expression. You will notice that they are prefixed by `$`.
 
 ```python3
 @swim
-def random(d=0.5, i=0):
+def random(p=0.5, i=0):
     print(P('T.U, T.Y, T.M, T.D, T.h, T.m, T.s, T.µ', i))
-    again(random, d=0.5, i=i+1)
+    again(random, p=0.5, i=i+1)
 ```
 
 - `T.U`: Unix Time, the current Unix Time.
@@ -68,9 +68,9 @@ You can write random numbers by using the letter `r`. By default, `r` will retur
 
 ```python3
 @swim
-def random(d=0.5, i=0):
-    S('cp', speed='$%20').out(i)
-    again(random, d=0.5, i=i+1)
+def random(p=0.5, i=0):
+    D('cp', speep='$%20', i=i)
+    again(random, p=0.5, i=i+1)
 ```
 
 Timed tokens make good *low frequency oscillators*, *ramps* or oscillating patterns. Playing with time tokens using modulos or the `sin()`, `cos()` or `tan()` functions is a great way to get generative results out of a predictible sequence. It is very important to practice doing this, especially if you are planning to use *fast swimming functions*. The faster you recurse, the better your timing resolution. You can start to enter into the realm of signal-like patterns that can be particularly good for generating fluid patterns.
@@ -79,9 +79,9 @@ Timed tokens make good *low frequency oscillators*, *ramps* or oscillating patte
 
 ```python3
 @swim
-def notes(d=0.5, i=0):
-    S('pluck', midinote='C5,D5,E5,F5,G5').out(i)
-    again(notes, d=0.5, i=i+1)
+def notes(p=0.5, i=0):
+    D('pluck', midinote='C5,D5,E5,F5,G5', i=i)
+    again(notes, p=0.5, i=i+1)
 ```
 
 Notes are one of the primitives you can use in patterns. Notes will always be converted to some MIDI value (an integer value between `0` and `127`). Notes will be converted to some MIDI value used by **SuperDirt**. If you need more precision, speak in hertzs (`freq=402.230239`). Notes are numbers too (!!). You can do math on them if you wish to. The syntax to write notes is the following:
@@ -97,9 +97,9 @@ Of course, if you are a robot, you might prefer to speak in numbers. Because not
 
 ```python3
 @swim
-def notes(d=0.5, i=0):
-    S('pluck', midinote='C5@penta').out(i)
-    again(notes, d=0.5, i=i+1)
+def notes(p=0.5, i=0):
+    D('pluck', midinote='C5@penta', i=i)
+    again(notes, p=0.5, i=i+1)
 ```
 
 You can use the `@` operator to **qualify** a note (or a number?). This will turn a note into  a collection of notes / structure based on the targetted note. `C@penta` will summon a major pentatonic scale based on the middle C note: `[60, 62, 64, 67, 69]`. Be careful while using them as they will instantly turn a single token into a list of `x` tokens. You might want to filter part of a qualifiers note collection.
@@ -226,9 +226,9 @@ qualifiers = {
 
 ```python3
 @swim
-def notes(d=0.5, i=0):
-    S('pluck', midinote='disco(C5@penta)'.out(i)
-    again(notes, d=0.5, i=i+1)
+def notes(p=0.5, i=0):
+    D('pluck', midinote='disco(C5@penta)', i=i)
+    again(notes, p=0.5, i=i+1)
 ```
 
 Functions can be used to further refine the effect of a modifier. There is a long list of functions that you can apply, such as `disco()` or `adisco()` as shown in the preceding example. If you ever wonder about the list of possible functions, refer to the **Sardinopedia** or enter any function name. If the function name is wrong, the list of possible functions will be printed out in the terminal.
@@ -238,9 +238,9 @@ Functions can be used to further refine the effect of a modifier. There is a lon
 
 ```python3
 @swim
-def notes(d=0.5, i=0):
-    S('pluck', midinote='disco(C5@maj7^4)'.out(i)
-    again(notes, d=0.5, i=i+1)
+def notes(p=0.5, i=0):
+    D('pluck', midinote='disco(C5@maj7^4)', i=i)
+    again(notes, p=0.5, i=i+1)
 ```
 
 You can write chord inversions using the `^` syntax. It will accept any valid expression like `^1~5`. You can also feed negative numbers for inverting a chord downwards. Chord inversions are not only for chords but they also work on lists, which means that you can write custom chords and transpose them up or down :)
@@ -249,9 +249,9 @@ You can write chord inversions using the `^` syntax. It will accept any valid ex
 
 ```python3
 @swim
-def notes(d=0.5, i=0):
-    S('pluck', midinote='disco(braid(C5+0|4|8@penta'))).out(i)
-    again(notes, d=0.5, i=i+1)
+def notes(p=0.5, i=0):
+    D('pluck', midinote='disco(braid(C5+0|4|8@penta))', i=i)
+    again(notes, p=0.5, i=i+1)
 ```
 You can use arithmetic operators on notes like if they were a regular number. That's because they are really just numbers! Random and time-dependant numbers are numbers too. Notes are numbers too so you can add a note to a note even if it doesn't really make sense. It will also not probably sound very good because notes are clamped in the range from `0` to `127`.
 
@@ -260,10 +260,10 @@ You can use arithmetic operators on notes like if they were a regular number. Th
 ##### Note polyphony
 
 ```python
-@swim 
-def poly(d=0.5, i=0):
-    S('<[superpiano]>', cutoff=500, midinote='<D@maj9>, <G@maj7^0>, <D@maj9>, <G@dim7^1>').out(i, 2, 0.25)
-    a(poly, d=P('0.5!4, 0.25!2', i), i=i+1)
+@swim
+def poly(p=0.5, i=0):
+    D('<[superpiano]>', cutoff=500, midinote='<D@maj9>, <G@maj7^0>, <D@maj9>, <G@dim7^1>', i=i)
+    a(poly, p=P('0.5!4, 0.25!2', i), i=i+1)
 ```
 
 You can use the `<` and `>` delimiters to make parts of your pattern polyphonic. You will soon notice that there are multiple types of polyphony available but the most notable of all, demonstrated in the example above, is the *note polyphony*. It allows you to superpose multiple note events in your patterns just like you expected. However, **Sardine** allows you to deal with polyphony in more unexpected ways. There a few rules to understand about polyphony and polyphonic messages. These rules can sound quite counter-intuitive if you think about it in a traditional way.
@@ -274,17 +274,17 @@ The **size** of a polyphonic event -- meaning the number of messages sent for on
 1) [1,2,3,4]
 2) [0,1]
 
-RESULT: 
+RESULT:
 1) [1,2,3,4]
 2) [0,1,0,1]
     | | | |
-   POLYPHONY 
+   POLYPHONY
 ```
 ```python
-@swim 
-def poly(d=0.5, i=0):
-    S('<[bd, superpiano]>', cutoff=500, midinote='<D@maj9>, <G@maj7^0>, <D@maj9>, <G@dim7^1>').out(i, 2, 0.25)
-    a(poly, d=P('0.5!4, 0.25!2', i), i=i+1)
+@swim
+def poly(p=0.5, i=0):
+    D('<[bd, superpiano]>', cutoff=500, midinote='<D@maj9>, <G@maj7^0>, <D@maj9>, <G@dim7^1>', i=i)
+    a(poly, p=P('0.5!4, 0.25!2', i), i=i+1)
 ```
 
 To illustrate the preceding rule we just talked about, here is a truly bizarre example. Half of our chord is played by a tuned bassdrum, the other half by a piano. Even though this may look odd, this is fully compliant with how parameters are handled by **Sardine**. We have two clear alternations, one between the `superpiano` and `bd` sound sets, the other between the four or five values that form our chords. It is then natural that half of our polyphony will be composed from a tuned bassdrum and the remaining half from a tuned piano. Once you get use to this novel way of thinking about polyphonic patterns, you will see that it opens up some space for interesting polyphonic interactions between sounds :)
@@ -294,24 +294,24 @@ It is currently not possible to limit the number of voices generated by an event
 ##### Parametric polyphony
 
 ```python
-@swim 
-def poly(d=0.5, i=0):
-    S('drum:[1,6]', 
-            speed='<[1,clamp(r, 0.1, 1)]>, <[2,1.9]>').out(i, 3)
-    S('drum:2',
-            cutoff='<[500:2000,500]*sin($%r*80/40)*10>').out(i, 2)
-    S('bd', shape=0.5).out(i, 4)
-    a(poly, d=0.5/2, i=i+1)
+@swim
+def poly(p=0.5, i=0):
+    D('drum:[1,6]',
+            speed='<[1,clamp(r, 0.1, 1)]>, <[2,1.9]>', i=i)
+    D('drum:2',
+            cutoff='<[500:2000,500]*sin($%r*80/40)*10>', i=i)
+    D('bd', shape=0.5, i=i)
+    a(poly, p=0.5/2, i=i+1)
 ```
-Everything can become polyphonic. Just wrap anything between `<` and `>` and you will return `x` events, one for each value. It allows you to be very creative with patterns. 
+Everything can become polyphonic. Just wrap anything between `<` and `>` and you will return `x` events, one for each value. It allows you to be very creative with patterns.
 
 ### C) Names
 
 ```python3
 @swim
-def names(d=0.5, i=0):
-    S('bd, pluck, bd, pluck:2+4').out(i)
-    again(names, d=0.5, i=i+1)
+def names(p=0.5, i=0):
+    D('bd, pluck, bd, pluck:2+4', i=i)
+    again(names, p=0.5, i=i+1)
 ```
 
 You are using name patterns since you first started to read the **Sardinopedia**! A single letter (if it's not already a note name) can be considered as a name. Be careful! There are a few hidden rules for names. Names can be one letter long but some letters are already taken by some parts of the language (such as `r`). Names cannot begin with a number. It is also forbidden to use any symbol inside your names.
@@ -319,7 +319,7 @@ You are using name patterns since you first started to read the **Sardinopedia**
 ### D) Addresses
 
 ```python3
-O(osc_client, "an/address, another/address", value=1, other_value=2).out()
+O(osc_client, "an/address, another/address", value=1, other_value=2)
 ```
 
 Addresses are just like names except that they can contain a `/` separator just like any other typical OSC address out there. They are not really distinct from a name. The difference is only conceptual and in the usage of your strings.
@@ -341,32 +341,34 @@ There are a few special operators that are only available when you deal with lis
 ### A) Slicing and indexing
 
 ```python
-@swim 
-def test_slice(d=0.5, i=0):
-    S('pluck:19', 
+@swim
+def test_slice(p=0.5, i=0):
+    D('pluck:19',
             legato=0.2,
-            midinote='([60,63,67,69, 71]&[i.i, i.i + 8])^(1~8)').out(i)
-    a(test_slice, d=0.125, i=i+1)
+            midinote='([60,63,67,69, 71]&[i.i, i.i + 8])^(1~8)',
+            i=i)
+    a(test_slice, p=0.125, i=i+1)
 ```
 
 You can get a slice or just one value from a list by using the special `&` operator. It will work with any list on the right side of the operator but it will only take the first and second value of it no matter what to compose a slice. The index value can be infinite because the index is looping on the list. You can feed a random number generator and get something out. On the down side, it can become quite complex to write very fast, so be careful with it:
 
 ```python
-@swim 
-def test_slice(d=0.5, i=0):
-    S('pluck:19', 
+@swim
+def test_slice(p=0.5, i=0):
+    D('pluck:19',
             legato=0.2,
-            midinote='[60,62, 63,67, 69, 71]^(1~5)&[r, r*4]').out(i)
-    a(test_slice, d=0.125, i=i+1)
+            midinote='[60,62, 63,67, 69, 71]^(1~5)&[r, r*4]',
+            i=i)
+    a(test_slice, p=0.125, i=i+1)
 ```
 
 ### B) Extend
 
 ```python
-@swim 
-def test_extend(d=0.5, i=0):
-    S('pluck:19', legato=0.2, midinote='[60,62]!2').out(i)
-    a(test_extend, d=0.125, i=i+1)
+@swim
+def test_extend(p=0.5, i=0):
+    D('pluck:19', legato=0.2, midinote='[60,62]!2', i=i)
+    a(test_extend, p=0.125, i=i+1)
 ```
 
 Just like with numbers, names and addresses, you can extend a list by calling the `!` operator on it. It will repeat the list `x` times.
@@ -374,10 +376,10 @@ Just like with numbers, names and addresses, you can extend a list by calling th
 ### C) Extend-repeat
 
 ```python
-@swim 
-def test_extend_repeat(d=0.5, i=0):
-    S('pluck:19', legato=0.2, midinote='[60,62,63]!!3').out(i) #note the repetition of values within the list
-    a(test_extend_repeat, d=0.125, i=i+1)
+@swim
+def test_extend_repeat(p=0.5, i=0):
+    D('pluck:19', legato=0.2, midinote='[60,62,63]!!3', i=i) #note the repetition of values within the list
+    a(test_extend_repeat, p=0.125, i=i+1)
 ```
 The variant `!!` now makes sense. It allows you to repeat each individual value in a list `x` times.
 
@@ -387,9 +389,9 @@ The variant `!!` now makes sense. It allows you to repeat each individual value 
 
 ```python3
 @swim
-def choosing_stuff(d=0.5, i=0):
-    S('bd|pluck', speed='1|2').out(i)
-    again(choosing_stuff, d=0.5, i=i+1)
+def choosing_stuff(p=0.5, i=0):
+    D('bd|pluck', speep='1|2', i=i)
+    again(choosing_stuff, p=0.5, i=i+1)
 ```
 The pipe operator `|` can be used on anything to make a 50/50% choice between two tokens. You can also chain them: `1|2|3|4`. The behavior of chaining multiple choice operators has not been clearly defined. The distribution might not be the one you expect.
 
@@ -397,9 +399,9 @@ The pipe operator `|` can be used on anything to make a 50/50% choice between tw
 
 ```python3
 @swim
-def ranges(d=0.5, i=0):
-    S('pluck|jvbass', speed='1~5').out(i)
-    again(ranges, d=0.5, i=i+1)
+def ranges(p=0.5, i=0):
+    D('pluck|jvbass', speep='1~5', i=i)
+    again(ranges, p=0.5, i=i+1)
 ```
 
 If you want to generate a number in the range `x` to `y` included, you can use the `~` operator. It spits an integer if you are using integers as boundaries but it will spit out a floating point number if you are using floating point numbers as boundaries. If you use an integer on one side and a floating point number on the other side, a floating point number will be returned. It can be used as an alternative to the `r` token for generating random numbers.
@@ -408,11 +410,12 @@ If you want to generate a number in the range `x` to `y` included, you can use t
 
 ```python3
 @swim
-def ramps(d=0.5, i=0):
-    S('amencutup:[0:10]', 
+def ramps(p=0.5, i=0):
+    D('amencutup:[0:10]',
         room='[0:1,0.1]',
-        cutoff='[1:10]*100').out(i)
-    again(ramps, d=0.5, i=i+1)
+        cutoff='[1:10]*100',
+        i=i)
+    again(ramps, p=0.5, i=i+1)
 ```
 
 You can generate ramps of integers using the `[1:10]` syntax. This works just like **Python**'s range function. Well, almost... it's way better! You can generate descending ramps easily: `[10:1]`. You can also generate ascending ramps of floating point numbers by precising a step other than `1`: `[1:10,0.5]`. Of course, this also works the other way around :)
@@ -421,9 +424,9 @@ You can generate ramps of integers using the `[1:10]` syntax. This works just li
 
 ```python3
 @swim
-def repeat_stuff(d=0.5, i=0):
-    S('pluck|jvbass', speed='1:2', midinote='C4!4, E4!3, E5, G4!4').out(i)
-    again(repeat_stuff, d=0.5, i=i+1)
+def repeat_stuff(p=0.5, i=0):
+    D('pluck|jvbass', speep='1:2', midinote='C4!4, E4!3, E5, G4!4', i=i)
+    again(repeat_stuff, p=0.5, i=i+1)
 ```
 
 The `!` operator inspired by **TidalCycles** is used to denote the repetition of a value. You can also sometimes use the `!!` operator from the same family. This operator is a bit different, because it is supposed to be used on lists. You can do maths on lists as well with **Sardine**, but this will be detailed in a section later on.
@@ -431,28 +434,28 @@ The `!` operator inspired by **TidalCycles** is used to denote the repetition of
 ### E) Silence
 
 ```python
-@swim 
-def silence_demo(d=0.5, i=0):
-    S('bd,...').out(i, div=1)
-    S('hh,., hh,..').out(i, div=1)
-    a(silence_demo, d=1/8, i=i+1)
+@swim
+def silence_demo(p=0.5, i=0):
+    D('bd,...', i=i, d=1)
+    D('hh,., hh,..', i=i, d=1)
+    a(silence_demo, p=1/8, i=i+1)
 ```
 
-You can use a dot (`.`) inside any pattern to indicate a silence. Silence is a very important and complex topic. Adding silences is a great way to generate interesting patterns. Silences are different for each sender because silence doesn't have the same meaning for a sampler, a MIDI output or an OSC output (`S()`, `M()`, `O()`):
+You can use a dot (`.`) inside any pattern to indicate a silence. Silence is a very important and complex topic. Adding silences is a great way to generate interesting patterns. Silences are different for each sender because silence doesn't have the same meaning for a sampler, a MIDI output or an OSC output (`D()`, `N()`, `O()`):
 
-- `S()`: a silence is the absence of a sample. The event will be skipped.
+- `D()`: a silence is the absence of a sample. The event will be skipped.
 
-- `M()`: a silence is the absence of a note. The event will be skipped.
+- `N()`: a silence is the absence of a note. The event will be skipped.
 
 - `O()`: a silence is the absence of an address. The event will be skipped.
 
 There is also the interesting case of what I like to call *'parametric silences'*. Take a look at the following example:
 
 ```python
-@swim 
-def silence_demo(d=0.5, i=0):
-    S('sitar', legato='0.5', speed='[1:4], .!8').out(i, div=1)
-    a(silence_demo, d=1/8, i=i+1)
+@swim
+def silence_demo(p=0.5, i=0):
+    D('sitar', legato='0.5', speep='[1:4], .!8', i=i, d=1)
+    a(silence_demo, p=1/8, i=i+1)
 ```
 
 We always have a sample here. There is no **real** silence but we have still have some silences included in the `speed` subpattern. It also has an effect. In the absence of a value for that silence, **Sardine** will backtrack and search the last value that could have been generated by the pattern. The result of the `speed` parameter will then be `[1,2,3,4,8,8,8,8,8,8,8,8]`. For people familiar with modular synthesis, this is pretty much equivalent to a *sample & hold* mechanism.
@@ -464,27 +467,27 @@ It is impossible to write a *parametric silence* composed only of silences. It d
 ### A) Amphibian variables
 
 ```python
-v.s = 60 # this is an amphibian variable
+V.s = 60 # this is an amphibian variable
 
-@swim 
+@swim
 def fun():
-    # Calling it and setting it to v.s + 5
-    M(note='v.s = v.s + 5').out()
+    # Calling it and setting it to V.s + 5
+    N(note='V.s = V.s + 5')
     if random() > 0.8:
-        v.s = 60 # resetting so it doesn't go too high
+        V.s = 60 # resetting so it doesn't go too high
     again(fun)
 ```
 
-There is a group of variables called *amphibian variables* that are both valid inside and outside the pattern notation. They are defined by `v` followed by a letter from the alphabet (uppercase or lowercase) : `v.a`, `v.A`, `v.Z`, `v.j`. These variables can be freely manipulated from the Python side or from the pattern side. They are totally transparent.
+There is a group of variables called *amphibian variables* that are both valid inside and outside the pattern notation. They are defined by `v` followed by a letter from the alphabet (uppercase or lowercase) : `V.a`, `V.A`, `V.Z`, `V.j`. These variables can be freely manipulated from the Python side or from the pattern side. They are totally transparent.
 
 ```python
-@swim 
-def fun(d=0.25):
+@swim
+def fun(p=0.25):
     # Now having fun with it
-    M(note='v.s = v.s + 5|2').out() # more fun
+    N(note='V.s = V.s + 5|2') # more fun
     if random() > 0.8:
-        v.s = 50
-    again(fun, d=0.25)
+        V.s = 50
+    again(fun, p=0.25)
 ```
 
 You can use them to leverage Python or the pattern syntax for what they do best: patterning or dealing with complex algorithmic transformations. Having them both available makes the pattern syntax even more expressive.
@@ -493,41 +496,41 @@ There is a finite list of actions you can perform on *amphibian variables*:
 
 - using them (just by calling them)
 
-- setting them (`v.i = 5`)
+- setting them (`V.i = 5`)
 
-- resetting them to 0 (`v.i.reset`)
+- resetting them to 0 (`V.i.reset`)
 
 ### B) Amphibian iterators
 
 ```python
 @swim
-def amphi_iter(d=0.25):
-    S('amencutup:[1:10]').out(i.i)
+def amphi_iter(p=0.25):
+    D('amencutup:[1:10]', i=I.i)
     if random() > 0.8:
-        i.i = 0
-    a(amphi_iter, d=0.25)
+        I.i = 0
+    a(amphi_iter, p=0.25)
 ```
 
-Similarly to *amphibian variables*, there is a thing called *amphibian iterators* that are valid on both sides. They are defined by `i` followed by a letter from the alphabet (uppercase or lowercase) : `i.a`, `i.A`, `i.Z`, `i.j`. They can be use as substitutes for your regular manual recursive iterators. In the example above, I am using an *amphibian iterator* to summon a breakbeat.
+Similarly to *amphibian variables*, there is a thing called *amphibian iterators* that are valid on both sides. They are defined by `I` followed by a letter from the alphabet (uppercase or lowercase) : `I.a`, `I.A`, `I.Z`, `I.j`. They can be use as substitutes for your regular manual recursive iterators. In the example above, I am using an *amphibian iterator* to summon a breakbeat.
 
 ```python
 @swim
-def amphi_iter(d=0.25):
-    S('amencutup:[1:10]', speed='1|2|i.i=0').out(i.i)
-    a(amphi_iter, d=0.25)
+def amphi_iter(p=0.25):
+    D('amencutup:[1:10]', speep='1|2|I.i=0', i=I.i)
+    a(amphi_iter, p=0.25)
 ```
 
 These iterators can be reset or set on the pattern side!
 
 ```python
 @swim
-def amphi_iter(d=0.25):
+def amphi_iter(p=0.25):
     if random() > 0.8:
-        i.i = [1, 5]
+        I.i = [1, 5]
     else:
-        i.i = [1, 2]
-    S('amencutup:[1:10]', speed='i.v|i.v=[1,2]').out(i.i)
-    a(amphi_iter, d=0.25)
+        I.i = [1, 2]
+    D('amencutup:[1:10]', speep='I.v|I.v=[1,2]', i=I.i)
+    a(amphi_iter, p=0.25)
 ```
 Similarly, you can define the step value between each value by providing a list of two numbers. This is valid on both sides.
 
@@ -565,12 +568,12 @@ I want to explore how far you can go by introducing functional concepts to handl
 ### D) Musical functions
 
 * `disco(x)`: Disco function. Every pair note down an octave.
-* `adisco(x)`: Anti-disco function. Every pair note up an octave. 
+* `adisco(x)`: Anti-disco function. Every pair note up an octave.
 * `bass(x)`: The first note of list is down an octave (not very useful).
 * `sopr(x)`: The last note of list is up an octave (not very useful).
 * `quant(x, y)`: The last note of list is up an octave (not very useful).
 
-### E) Voice Leading 
+### E) Voice Leading
 
 These are two voice leading algorithms. These are only temporary until I figure out a better solution. They usually take a list of four note chords and arrange the voice to minimise movement. They work great but they are not the funniest thing you've ever seen. I'll work on them to make it better!
 
@@ -599,5 +602,3 @@ To be documented:
 ### I) Filtering
 
 * `filt(x, y)`:
-
-

--- a/docs/documentation/sardinopedia/patterning.md
+++ b/docs/documentation/sardinopedia/patterning.md
@@ -2,7 +2,7 @@
 
 By nature, *swimming functions* are repetitive. Almost everything you play with is falling into a time loop. Strict repetition can be come pretty boring after a while, and you need to find a way to define events that will gradually change in time, whether it is because they are sequence of events, random events, mutating events, etc... Sequencing and patterning is the big deal for *live-coders*. That's how they think about composition / improvisation, that's how they write interesting music by patterning synthesizers, audio samples, custom events and much more. If you go down the rabbit hole, you can also pattern your patterns. You can also pattern the functions altering your patterns. There is no limit to it, only what you are trying to define and play with.
 
-Thinking about music being composed with patterns, recursion and time loops is a deparature from the timeline / score model we are used to when thinking about music being written on scores or being recorded on tape. By patterning and thinking about loops, we enter into a different relationship with sound materials and the management of musical information. 
+Thinking about music being composed with patterns, recursion and time loops is a deparature from the timeline / score model we are used to when thinking about music being written on scores or being recorded on tape. By patterning and thinking about loops, we enter into a different relationship with sound materials and the management of musical information.
 
 It would have been weird to design **Sardine** without taking into account the fact that **patterning** is as much needed as control over the temporal execution of code. **Sardine** is taking some inspiration from [ORCA](https://github.com/hundredrabbits/Orca) (Devine Lu Linvega), [FoxDot](https://github.com/Qirky/FoxDot) (Ryan Kirkbride) and [TidalCycles](https://tidalcycles.org) (Alex McLean and colaborators). These systems, among others, have been designed just like **Sardine** around the idea of patterning values in musical time. They all choose a different route to do so, and come up in exchange with interesting concepts about what an event or even what time is in a musical improvisation system. **Sardine** is proposing its own flavor of patterning that you will soon discover :)
 
@@ -28,36 +28,36 @@ You can use the `P()` object to get a *generic interface* to **Sardine** pattern
 
 ```python3
 @swim
-def free(d=0.5, i=0):
+def free(p=0.5, i=0):
     print(P('1,2,3,4', i))
-    again(free, d=0.5, i=i+1)
+    again(free, p=0.5, i=i+1)
 ```
 
 In the example above, we are just using a *swimming function* to print the result of a pattern. It just goes through each element in sequence. That is because we are feeding an **iterator** to the `P(pattern, iterator)` function. Try to change that **iterator**. It'll already produce a variation on the pattern without even touching the pattern itself:
 
 ```python3
 @swim
-def free(d=0.5, i=0):
+def free(p=0.5, i=0):
     print(P('1,2,3,4', i if random() > 0.5 else i+2))
-    again(free, d=0.5, i=i+1)
+    again(free, p=0.5, i=i+1)
 ```
 
 The good thing with writing your own language is that you can write it to make some things more easy to accomplish. Why counting to 4 by writing down each number? We already have something to do it for us:
 
 ```python3
 @swim
-def free(d=0.5, i=0):
+def free(p=0.5, i=0):
     print(P('[1:4]', i if random() > 0.5 else i+2))
-    again(free, d=0.5, i=i+1)
+    again(free, p=0.5, i=i+1)
 ```
 
 Ok but now what if we would like to combine this pattern with the same one in the opposite direction? We can use functions from the `FuncLibrary` to do so:
 
 ```python3
 @swim
-def free(d=0.5, i=0):
+def free(p=0.5, i=0):
     print(P('pal([1:4])', i if random() > 0.5 else i+2))
-    again(free, d=0.5, i=i+1)
+    again(free, p=0.5, i=i+1)
 ```
 
 You might sometimes feel a bit lost when writing complex patterns. As you'll soon discover, there are many features to the language. Always remember that you can print out patterns! You can observe them without making sound and you can even use them to do other tasks if you prefer. **Sardine** is cool for music playing but you can do much more with it. There are a few other things you can do to observe pattern in detail:
@@ -73,36 +73,38 @@ You might sometimes feel a bit lost when writing complex patterns. As you'll soo
 
 ```python3
 @swim
-def boom(d=0.5, i=0):
-    S('bd', 
+def boom(p=0.5, i=0):
+    D('bd',
         cutoff='r*2000',
-        speed='1,2,3,4').out(i)
-    again(boom, d=0.5, i=i+1)
+        speep='1,2,3,4',
+        i=i)
+    again(boom, p=0.5, i=i+1)
 ```
 
 Conceptually, *senders* are pattern sandwiches. It is a collection of lists sharing a common **iterator**. They all form a common event by merging together in a final message. The easiest way to deal with this is to have one and only one iterator but of course, if you don't like it that way, you can have multiple **iterators** in a single *sender*.
 
 ```python3
 @swim
-def boom(d=0.5, i=0):
-    S('bd', 
+def boom(p=0.5, i=0):
+    D('bd',
         cutoff=P('2000!4, 4000!2, 8000!3, 200~5000', i+2),
-        speed='1,2,3,4').out(i)
-    again(boom, d=0.5, i=i+1)
+        speep='1,2,3,4',
+        i=i)
+    again(boom, p=0.5, i=i+1)
 ```
 
 It can even be more extreme than this but it all depends on what you are trying to achieve! You already saw that the tail method of your *sender* also have additional parameters that you can use to further refine the message composition.
 
-## IV - Iterators are cool 
+## IV - Iterators are cool
 
 ```python3
 @swim
-def boom(d=0.5, i=0):
-    S('bd', 
+def boom(p=0.5, i=0):
+    D('bd',
         cutoff=P('r*2000, 500, 1000', i%2),
-        speed='1, 2, 3, 4').out(randint(1,4))
-    again(boom, d=0.5, i=i+1)
+        speep='1, 2, 3, 4',
+        i=randint(1,4))
+    again(boom, p=0.5, i=i+1)
 ```
 
 You can be creative with **iterators** and easily generate semi-random sequences, drunk walks, reversed sequences, etc... Be sure to always have a few different iterators close by to morph your sequences really fast. I know that writing complex patterns is nice but they are nothing without good iterators.
-

--- a/docs/documentation/sardinopedia/rhythm.md
+++ b/docs/documentation/sardinopedia/rhythm.md
@@ -4,16 +4,16 @@
 
 ```python3
 @swim
-def bd(d=0.5):
+def bd(p=0.5):
     if often():
-        S('bd').out()
+        D('bd')
     if sometimes():
-        S('hh').out()
+        D('hh')
     else:
-        S('pluck').out()
-    # condensed 
-    S('sd', trig=1 if sometimes() else 0).out()
-    again(bd, d=0.5)
+        D('pluck')
+    # condensed
+    D('sd', trig=1 if sometimes() else 0)
+    again(bd, p=0.5)
 ```
 
 Building rhythms based on chance that an event will happen. Rolling a dice. These small functions are borrowed from **TidalCycles** that is using them intensively in its very thorough patterning system.
@@ -22,9 +22,9 @@ Building rhythms based on chance that an event will happen. Rolling a dice. Thes
 
 ```python3
 @swim
-def bd(d=0.5, i=0):
-    S('bd', trig=bin(20103)).out(i)
-    again(bd, d=0.5, i=i+1)
+def bd(p=0.5, i=0):
+    D('bd', trig=bin(20103), i=i)
+    again(bd, p=0.5, i=i+1)
 ```
 Using the binary representation of a number to build a rhythm. You don't need to know what the representation is to get an interesting rhythm out of it. Feed anything to the `bin` function and get something out!
 
@@ -32,11 +32,11 @@ Using the binary representation of a number to build a rhythm. You don't need to
 
 ```python3
 @swim
-def bd(d=0.5, i=0):
-    S('bd:r*20', trig=euclid(1,4)).out(i)
-    S('hh:r*20', trig=euclid(6,8)).out(i)
-    S('sd:r*20', trig=euclid(2,4)).out(i)
-    again(bd, d=0.5, i=i+1)
+def bd(p=0.5, i=0):
+    D('bd:r*20', trig=euclid(1,4), i=i)
+    D('hh:r*20', trig=euclid(6,8), i=i)
+    D('sd:r*20', trig=euclid(2,4), i=i)
+    again(bd, p=0.5, i=i+1)
 ```
 Building euclidian rhythms by using the `trig` argument. Note that this is not really an euclidian rhythm but it sure does look and feel like it. Trig allows you to skip an event.
 
@@ -44,11 +44,11 @@ Building euclidian rhythms by using the `trig` argument. Note that this is not r
 
 ```python3
 @swim
-def bd(d=0.5, i=0):
-    S('bd:r*20', trig=euclid(1,4)).out(i)
-    S('hh:0~5', trig=euclid(6,8)).out(i)
-    S('sd:$%20', trig=euclid(2,4)).out(i)
-    again(bd, d=P('0.5!8, 0.25!4', i), i=i+1)
+def bd(p=0.5, i=0):
+    D('bd:r*20', trig=euclid(1,4), i=i)
+    D('hh:0~5', trig=euclid(6,8), i=i)
+    D('sd:$%20', trig=euclid(2,4), i=i)
+    again(bd, p=P('0.5!8, 0.25!4', i), i=i+1)
 ```
 Pattern the recursion delay to get free rhythms! You can even skip playing with `trig` and just play with the recursion `delay` if you feel like it!
 
@@ -56,27 +56,25 @@ Pattern the recursion delay to get free rhythms! You can even skip playing with 
 
 ```python3
 @swim
-def zoom(d=0.5, i=0):
-    S('bd:r*20').out(i)
+def zoom(p=0.5, i=0):
+    D('bd:r*20', i=i)
     sleep(0.25)
-    S('hh:r*20', trig=euclid(6,8)).out(i)
+    D('hh:r*20', trig=euclid(6,8), i=i)
     sleep(0.125)
-    S('sd:r*20', trig=euclid(2,4)).out(i)
-    again(zoom, d=0.5, i=i+1)
+    D('sd:r*20', trig=euclid(2,4), i=i)
+    again(zoom, p=0.5, i=i+1)
 ```
 Create rhythm using the `sleep()` function. Fully compatible with everything else! It is usually a good idea to use `sleep()` after having composed something complex to slice time even more.
 
 ### Silence rhythms
 
 ```python3
-@swim 
-def silence_rhythm(d=0.5, i=0):
-    S('bd').out(i, div=4)
-    S('hh:2').out(i, div=2)
-    S('drum:2+r*5').out(i, div=3)
-    a(silence_rhythm, d=1/8, i=i+1)
+@swim
+def silence_rhythm(p=0.5, i=0):
+    D('bd', i=i, d=4)
+    D('hh:2', i=i, d=2)
+    D('drum:2+r*5', i=i, d=3)
+    a(silence_rhythm, p=1/8, i=i+1)
 ```
 
-Play with the `div` amount to generate interesting rhythms.
-
-
+Play with the `divisor` amount to generate interesting rhythms.

--- a/docs/documentation/sardinopedia/sampling.md
+++ b/docs/documentation/sardinopedia/sampling.md
@@ -4,17 +4,17 @@ Sampling is taken care of by **SuperDirt** but I don't think that an official do
 
 ```python3
 @swim
-def hh(d=0.5):
-    S('hh').out(i)
-    again(hh, d=0.5)
+def hh(p=0.5):
+    D('hh', i=i=
+    again(hh, p=0.5)
 ```
 This will play the first file in the `hh` folder, loaded via **SuperDirt**.
 
 ```python3
 @swim
-def hh(d=0.5):
-    S('hh:1').out(i)
-    again(hh, d=0.5)
+def hh(p=0.5):
+    D('hh:1', i=i)
+    again(hh, p=0.5)
 ```
 This will play the second file, etc... Numbers wrap around, so you can't overflow and play a file that doesn't exist. It means that you can iterate freely on the sample number without fear.
 
@@ -22,9 +22,9 @@ This will play the second file, etc... Numbers wrap around, so you can't overflo
 
 ```python
 @swim
-def hh(d=0.5):
-    S('jvbass:0', speed='1,2,3,4').out(i.i)
-    again(hh, d=0.5)=
+def hh(p=0.5):
+    D('jvbass:0', speed='1,2,3,4', i=I.i)
+    again(hh, p=0.5)
 ```
 You can pitch samples up or down by changing the playback speed. `1` is the normal playback speed, `2` twice as fast and `0` will not play anything at all. You can play a file in reverse speed by inputting negative values such as `-1` for backwards normal speed, etc... Beware of very low numbers close to `0` as they will be sometimes harder to hear but will still take memory to be played, especially if there is nothing to stop them.
 
@@ -32,17 +32,17 @@ You can pitch samples up or down by changing the playback speed. `1` is the nor
 
 ```python
 @swim
-def loud(d=0.5):
-    S('bd', speed='1', amp=1).out(i.i)
-    again(hh, d=0.5)
+def loud(p=0.5):
+    D('bd', speed='1', amp=1, i=I.i)
+    again(hh, p=0.5)
 ```
 This bassdrum will be played very loud. The `amp` parameter will determine the volume of audio playback for a given sample. `0` equals to silence. `1` corresponds to full volume, with distortion of the audio signal being allowed for larger values.
 
 ```python
 @swim
-def loud(d=0.5):
-    S('bd', speed='1', gain=1).out(i.i)
-    again(hh, d=0.5)
+def loud(p=0.5):
+    D('bd', speed='1', gain=1, i=I.i)
+    again(hh, p=0.5)
 ```
 Gain is slightly similar to `amp`. The difference lies in the scaling. While `amp` is defined as a value on a linear scale, `gain` is defined on an exponential scale. The higher you go, the more subtle the change. Folks from the TidalCycles documentation recommend a value between `0` and `1.5` for better use.
 
@@ -50,27 +50,27 @@ Gain is slightly similar to `amp`. The difference lies in the scaling. While `am
 
 ```python
 @swim
-def cutting(d=0.5):
-    S('jvbass:0', legato=0.1).out(i.i)
-    again(cutting, d=0.5)
+def cutting(p=0.5):
+    D('jvbass:0', legato=0.1, i=I.i)
+    again(cutting, p=0.5)
 ```
 The `legato` parameter can be used to cut a sample hard after a given amount of time. It is a very useful parameter not to overlap sounds too much if you ever needed it. It can also be used a safety parameter for playing back long samples without loosing control over the stop time.
 
 
 ```python
 @swim
-def cutting(d=0.5):
-    S('jvbass:0', cut=1).out(i.i)
-    again(cutting, d=0.5)
+def cutting(p=0.5):
+    D('jvbass:0', cut=1, i=I.i)
+    again(cutting, p=0.5)
 ```
 The `cut` parameter will cut the previously playing sample if trigerred on the same orbit. This is just like `legato` except that the duration of the `legato` will depend on the time spent between two sounds.
 
 
 ```python
 @swim
-def cutting(d=0.5):
-    S('jvbass:0', sustain=0.01).out(i.i)
-    again(cutting, d=0.5)
+def cutting(p=0.5):
+    D('jvbass:0', sustain=0.01, i=I.i)
+    again(cutting, p=0.5)
 ```
 The `sustain` value will determine the length of audio playback (in seconds).
 
@@ -78,9 +78,9 @@ The `sustain` value will determine the length of audio playback (in seconds).
 
 ```python
 @swim
-def position(d=0.5):
-    S('fire', speed='1', begin=0.1, end=0.5, amp=0.5).out(i.i)
-    again(position, d=2)
+def position(p=0.5):
+    D('fire', speed='1', begin=0.1, end=0.5, amp=0.5, i=I.i)
+    again(position, p=2)
 ```
 When playing long audio samples, you might want to *scroll* through the file, moving the playhead accross the file. You can use the `begin` and `end` parameters (from `0` to `1`) to set the begin playback point and the end playback point. You can pattern the `begin` parameter with great expressive effect.
 
@@ -88,12 +88,12 @@ When playing long audio samples, you might want to *scroll* through the file, mo
 
 ```python
 @swim
-def streeeetch(d=0.5):
-    S('fire', 
+def streeeetch(p=0.5):
+    D('fire',
             begin='r/2',
             legato=1,
             amp=0.5,
-            timescale=2.7).out()
+            timescale=2.7)
     a(streeeetch)
 ```
 

--- a/docs/documentation/sardinopedia/senders.md
+++ b/docs/documentation/sardinopedia/senders.md
@@ -12,42 +12,38 @@ You will see that learning how to *swim* was kind of the big deal. Things will n
 
 ## I - Anatomy of Senders
 
-A **Sender** is an *event generator*. It describes one event. This event can mutate depending on multiple factors such as patterns, randomness, chance operations, clever **Python** string formatting, etc... A single sender can be arbitrarily long depending on the precision you want to give to each event. This object will only take **one method**: `.out()`. Wait? A long object, and a tail method? Does it ring a bell? It looks... just like a sardine.
+A **Sender** is an *event generator*. It describes one event. This event can mutate depending on multiple factors such as patterns, randomness, chance operations, clever **Python** string formatting, etc... A single sender can be arbitrarily long depending on the precision you want to give to each event. This sender can also take some optional *tail arguments*. Wait? A long function, and tail arguments? Does it ring a bell? It looks... just like a sardine.
 
 ```
-       /`-._                          /`-._
-     _/,.._/                        _/,.._/
-  ,-'   ,  `-:,.-')        _     ,-'   ,  `-:,.-')        _
- : S(...):';  _  {    .out(_)   : M(...):';  _  {    .out(_)    ... and more
-  `-.  `' _,.-\`-.)        +     `-.  `' _,.-\`-.)        +
-     `\\``\,.-'                     `\\``\,.-'
-                               
+       /`-._                   /`-._
+     _/,.._/                 _/,.._/
+  ,-'   ,  `-:,.-')       ,-'   ,  `-:,.-')        
+ : D(...):';  _  {    +  : N(...):';  _  {    +  ... and more
+  `-.  `' _,.-\`-.)      `-.  `' _,.-\`-.)     
+     `\\``\,.-'             `\\``\,.-'
+
 ```
 
 ### Writing the body
 
-Every sender (`M()`, `O()`, `S()`) is an object taking *arguments* and *keyword arguments*. **Arguments are mandatory**, and keyword arguments optional. These arguments will define your event:
+Every sender (`N()`, `O()`, `D()`) is a function taking *arguments* and *keyword arguments*. **Arguments are mandatory**, and keyword arguments optional. These arguments will define your event:
 
 ```python
-S('bd', speed='[1:2,0.5]', legato=1, shape=0.5) # Heavy drumbass
-M(note='C@min7^1', dur=2, channel=0)            # Short MIDI chord
+D('bd', speep='[1:2,0.5]', legato=1, shape=0.5) # Heavy drumbass
+N(note='C@min7^1', dur=2, channel=0)            # Short MIDI chord
 ```
 
-You will have to learn what *arguments* each sender can receive. They all have a speciality. Despite the fact that they look and behave similarly, the event they describe is very different in nature depending on the type. 
-
-!!! warning
-
-    Note that **Sardine** is still missing some pieces. There is currently no way to easily pattern some very common **MIDI** messages such as *control changes*, *program changes*, etc... Don't worry! You can still pattern all of this very easily by doing `cc(control=P('0,1,2',i), value=P('1~127'))`. It's a just a bit more verbose compared to what it could be if ever I was feeling like adding this to the codebase! It will eventually happen, I promise!
+You will have to learn what *arguments* each sender can receive. They all have a speciality. Despite the fact that they look and behave similarly, the event they describe is very different in nature depending on the type.
 
 ### Precising the tail
 
-The tail of a sender is always the `.out()` method. Without it, no message is sent. We have already seen the tail in the *swimming functions* section. If you are here because of it, you've found the right place to look at! The `.out()` method takes three arguments:
+The tail of a sender consists of optional arguments specifying when and how to send events. We have already seen the tail in the *swimming functions* section. If you are here because of it, you've found the right place to look at! These arguments are:
 
-- `i` (*int*): the iterator for patterning. **Mandatory** for the two other arguments to work properly. This **iterator** is the index of the values extracted from your linear list-like patterns (your **arguments** and **keyword arguments**). How this index will be interpreted will depend on the next two arguments.
+- `iterator (i for short)` (*int*): the iterator for patterning. **Mandatory** for the two other arguments to work properly. This **iterator** is the index of the values extracted from your linear list-like patterns (your **arguments** and **keyword arguments**). How this index will be interpreted will depend on the next two arguments.
 
-- `div` (*int*): **a timing divisor**. It is very much alike a modulo operation. If `div=4`, the event will be emitted once every 4 iterations. The default is `div=1`, where every event is a hit! Be careful not to set a `div=1` on a very fast *swimming function* as it could result in catastrophic failure / horrible noises. There is no parachute out in the open sea.
+- `divisor (d for short)` (*int*): **a timing divisor**. It is very much alike a modulo operation. If `p=4`, the event will be emitted once every 4 iterations. The default is `p=1`, where every event is a hit! Be careful not to set a `p=1` on a very fast *swimming function* as it could result in catastrophic failure / horrible noises. There is no parachute out in the open sea.
 
-- `rate` (*float*): a speed factor for iterating over pattern values. It will slow down or speed up the iteration speed, the speed at which the pattern values are indexed on. For the pattern `1, 2, 3` and a rate of `0.5`, the result will be perceptually similar to `1, 1, 2, 2, 3, 3`.
+- `rate (r for short)` (*float*): a speed factor for iterating over pattern values. It will slow down or speed up the iteration speed, the speed at which the pattern values are indexed on. For the pattern `1, 2, 3` and a rate of `0.5`, the result will be perceptually similar to `1, 1, 2, 2, 3, 3`.
 
 I know, it doesn't make any sense written like so.. That's something you have to see represented differently. Take a look at `tail` arguments values. Notice how different values will produce different iteration speeds:
 
@@ -56,11 +52,11 @@ I know, it doesn't make any sense written like so.. That's something you have to
 Now, try exploring this idea using this dummy pattern:
 ```python
 @swim
-def ocean_periodicity(d=0.5, i=0):
-    S('bd, hhh, sn, hhh', speed='1,2', freq='r*800').out(i, 2, 0.5)
-    a(ocean_periodicity, d=0.5, i=i+1)
+def ocean_periodicity(p=0.5, i=0):
+    D('bd, hhh, sn, hhh', speep='1,2', freq='r*800', i=i, d=2, r=0.5)
+    a(ocean_periodicity, p=0.5, i=i+1)
 ```
-Don't touch to the pattern itself, just change values in the `.out()` method. Try to be more familiar with it. You can change the recursion speed to notice more clearly how the pattern will evolve with time.
+Don't touch to the pattern itself, just change values in the tail arguments. Try to be more familiar with it. You can change the recursion speed to notice more clearly how the pattern will evolve with time.
 
 ### Tips for writing Senders
 
@@ -68,28 +64,22 @@ Python is *extremely* flexible and expressive. The language makes it a breeze to
 
 ```python
 params = {'loud': {'amp': 2, 'shape': 0.9}, 'soft': {'amp': 0.1, 'legato': 0.1}}
-S('bd', **params['loud'])
+D('bd', **params['loud'])
 ```
 
-There is also a hidden benefit to separating the `.out()` method from the object initialisation. You can store events somewhere without having to send them immediately. :
-```python
-drumkit = {'bass': S('bd'), 'hat': S('hhh'), 'snare': S('sn')}
-drumkit['bass'].out()
-```
-
-These examples look very verbose, but try to imagine cases where *they will save you from an even more verbose situation*. It can happen very quickly when you try to play with many events at the same time, or when you will start imagining grouping sounds together or modifying multiple parameters in different events at the same time.
+This example looks very verbose, but try to imagine cases where *it will save you from an even more verbose situation*. It can happen very quickly when you try to play with many events at the same time, or when you will start imagining grouping sounds together or modifying multiple parameters in different events at the same time.
 
 
-## II - The Sound Sender
+## II - The Dirt Sender
 
-The **Sound** or **SuperDirt** sender is a sender specialised in talking with **SuperCollider** and more specifically with the sound engine used by [TidalCycles](https://tidalcycles.org). I'm using the synthesis / sampling backend written and supported by [Julian Rohrhuber](https://www.rsh-duesseldorf.de/en/institutes/institute-for-music-and-media/faculty/rohrhuber-julian/) that many live-coders worldwide are also using. It is very stable, very flexible and highly-configurable. 
+The **Dirt** or **SuperDirt** sender is a sender specialised in talking with **SuperCollider** and more specifically with the sound engine used by [TidalCycles](https://tidalcycles.org). I'm using the synthesis / sampling backend written and supported by [Julian Rohrhuber](https://www.rsh-duesseldorf.de/en/institutes/institute-for-music-and-media/faculty/rohrhuber-julian/) that many live-coders worldwide are also using. It is very stable, very flexible and highly-configurable.
 
 This sender is the most complex you will have to interact with and it is entirely optional if you wish to use **Sardine** only to sequence MIDI and OSC messages. If we dive into its architecture, we will soon find out that this sender is a specialised OSC sender that talks exclusively with **SuperDirt** using special timestamped messages.
 
-The body of the sender is always: 
+The body of the sender is always:
 
 ```python
-S('sound', keyword=value_or_pattern, keyword2=value_or_pattern)
+D('sound', keyworp=value_or_pattern, keyword2=value_or_pattern)
 ```
 
 The first argument defining the sound or synthesizer you are willing to trigger is not optional. Without it, you can be sure that the sender will crash because it cannot apply parameters to something that is not defined. The keyword parameters are the names of your **SuperDirt** parameters. It can be standard parameters, orbit parameters (audio bus) or parameters related to the synthesizer you are using. You will find more about this in the Reference section that is listing pretty much all of them!
@@ -100,19 +90,19 @@ You will feel a bit lost at first but this is a case where you learn a lot by do
 
 ```python3
 @swim
-def bd(d=0.5):
-    S('bd').out()
-    again(bd, d=0.5)
+def bd(p=0.5):
+    D('bd')
+    again(bd, p=0.5)
 ```
-A simple bassdrum playing on every half-beat. This is the most basic sound-making function you can write. 
+A simple bassdrum playing on every half-beat. This is the most basic sound-making function you can write.
 
 ### Complex Bassdrum
 
 ```python3
 @swim
-def bd(d=0.5):
-    S('bd', speed='r*4', legato='r', cutoff='100+0~4000').out()
-    again(bd, d=0.25)
+def bd(p=0.5):
+    D('bd', speep='r*4', legato='r', cutoff='100+0~4000')
+    again(bd, p=0.25)
 ```
 A simple bassdrum but some parameters have been tweaked to add some randomness to the result. See how patterns can be used to make your keyword arguments more dynamic. The additional parameters are :
 
@@ -124,9 +114,9 @@ A simple bassdrum but some parameters have been tweaked to add some randomness t
 
 ```python3
 @swim
-def bd(d=0.5, i=0):
-    S('amencutup:0~20').out(i)
-    again(bd, d=0.25, i=i+1)
+def bd(p=0.5, i=0):
+    D('amencutup:0~20', i=i)
+    again(bd, p=0.25, i=i+1)
 ```
 Picking a random sample in a folder containing slices of the classic [amen break](https://en.wikipedia.org/wiki/Amen_break). You could have a successful career doing this in front of audiences. Once again, the *magic* happens with the `sample:r*X` notation, which randomizes which sample is read on each execution, making it unpredictable.
 
@@ -134,42 +124,42 @@ Picking a random sample in a folder containing slices of the classic [amen break
 
 ```python3
 @swim
-def bd(d=0.5, i=0):
-    S('bd,hh,sn,hh').out(i)
-    again(bd, d=0.5, i=i+1)
+def bd(p=0.5, i=0):
+    D('bd,hh,sn,hh', i=i)
+    again(bd, p=0.5, i=i+1)
 ```
-Your classic four-on-the-floor written on one line. One sound is played after the other. All arguments and keyword arguments can be patterned. 
+Your classic four-on-the-floor written on one line. One sound is played after the other. All arguments and keyword arguments can be patterned.
 
 ### Piling up / Polyphony
 
 ```python3
 @swim
-def pluck(d=0.5, i=0):
-    S('pluck').out(i)
-    S('pluck:1').out(i)
-    S('pluck:2').out(i)
-    S('pluck:3').out(i)
-    again(pluck, d=0.5, i=i+1)
+def pluck(p=0.5, i=0):
+    D('pluck', i=i)
+    D('pluck:1', i=i)
+    D('pluck:2', i=i)
+    D('pluck:3', i=i)
+    again(pluck, p=0.5, i=i+1)
 ```
 
-You can stack events easily by just calling `S()` multiple times. In the above example, it happens that `pluck` samples are nicely order and are generating a chord if you struck them in parallel. How cool! But wait, there is more to it:
+You can stack events easily by just calling `D()` multiple times. In the above example, it happens that `pluck` samples are nicely order and are generating a chord if you struck them in parallel. How cool! But wait, there is more to it:
 
 ```python3
 @swim
-def pluck(d=0.5, i=0):
-    S('<pluck:[0:4]>', octave=6).out(i)
-    again(pluck, d=0.5, i=i+1)
+def pluck(p=0.5, i=0):
+    D('<pluck:[0:4]>', octave=6, i=i)
+    again(pluck, p=0.5, i=i+1)
 ```
 
 You can also stack sounds by using polyphony. With **Sardine**, polyphony is not a concept reserved to notes. Every pattern can be polyphonic (sample names, speeds, adresses, etc...).
 
 ### More examples...
 
-Check out the `Demos` section to find out how people are using the **S** sender. 
+Check out the `Demos` section to find out how people are using the **D** sender.
 
-## II - MIDI Sender
+## II - MIDI Notes Sender
 
-The **MIDI** or **M** sender is a sender specialised for emitting **MIDI** *note-on* and *note-off* messages just like on a music tracker or DAW. It does not have a lot of arguments, and if you have some degree of familiarity with the **MIDI** protocol, you will feel at home pretty quickly:
+The **MIDI Notes** or **N** sender is a sender specialised for emitting **MIDI** *note-on* and *note-off* messages just like on a music tracker or DAW. It does not have a lot of arguments, and if you have some degree of familiarity with the **MIDI** protocol, you will feel at home pretty quickly:
 
 - **note**: your note number, between `0` and `127`. You can of course use patterns, and patterns can be patterns of notes (special syntax for writing chords, scales, notes, etc...). Values are clamped. If you enter an incredibly big number, it will be clamped to `127`. The same thing goes for small or negative numbers that will be brought back to `0`.
 
@@ -186,15 +176,18 @@ That's it! You might wonder: where are my other MIDI messages? We got them cover
 - `pwheel(channel: int, pitch: int)`: pitch wheel message.
 - `sysex(data: list)`: custom SYSEX message.
 
-My plan is to cover all of the messages. The page will be updated later with a new `MM()` **Sender** specialised in custom MIDI messages.
+!!! info
+
+    Note that since version 0.2 **Sardine** has senders for *control changes* and *program changes*, respectively named `CC` and `PC`!
+
 
 ### Sending a note
 
 ```python3
 @swim
-def midi(d=0.5, i=0):
-    M().out()
-    again(midi, d=0.5, i=i+1)
+def midi(p=0.5, i=0):
+    N()
+    again(midi, p=0.5, i=i+1)
 ```
 No argument required to send a **MIDI** Note (`60`) at full velocity (`127`) on the first default **MIDI** channel. Arguments are only used to specify further or to override default values.
 
@@ -202,9 +195,9 @@ No argument required to send a **MIDI** Note (`60`) at full velocity (`127`) on 
 
 ```python3
 @swim
-def midi(d=0.5, i=0):
-    M(note='C5,D5,E5,G5,E5,D5,G5,C5').out(i)
-    again(midi, d=0.5, i=i+1)
+def midi(p=0.5, i=0):
+    N(note='C5,D5,E5,G5,E5,D5,G5,C5', i=i)
+    again(midi, p=0.5, i=i+1)
 ```
 Playing a little melody by tweaking the `note` argument.
 
@@ -212,12 +205,13 @@ Playing a little melody by tweaking the `note` argument.
 
 ```python3
 @swim
-def midi(d=0.5, i=0):
-    M(channel='0,1,2,3',
+def midi(p=0.5, i=0):
+    N(channel='0,1,2,3',
       velocity='20 + (r*80)',
       dur=0.4,
-      note='C5,D5,E5,G5,E5,D5,G5,C5').out(i)
-    again(midi, d=0.5, i=i+1)
+      note='C5,D5,E5,G5,E5,D5,G5,C5',
+      i=i)
+    again(midi, p=0.5, i=i+1)
 ```
 The same melody spreaded out on three **MIDI** channels (one per note) with random velocity.
 
@@ -225,27 +219,28 @@ The same melody spreaded out on three **MIDI** channels (one per note) with rand
 
 ```python3
 @swim
-def midi(d=0.5, i=0):
-    M(channel='0,1,2,3',
+def midi(p=0.5, i=0):
+    N(channel='0,1,2,3',
       velocity='20 + (r*80)',
       dur=0.4,
-      note='C5,D5,E5,G5,E5,D5,G5,C5').out(i)
+      note='C5,D5,E5,G5,E5,D5,G5,C5',
+      i=i)
     pgch(P('1,2,3,4', i)) # switching
     cc(channel=0, control=20, value=50) # control
-    again(midi, d=0.5, i=i+1)
+    again(midi, p=0.5, i=i+1)
 ```
 Switching between program `1`, `2`, `3` and `4` on your MIDI Synth. Sending a control change on channel `0`, number `20` for a value of `50`.
 
 ### More examples...
 
-Check out the `Demos` section to find out how people are using the **M** sender. 
+Check out the `Demos` section to find out how people are using the **N** sender.
 
 ## III - OSC Sender
 
 The **OSC** Sender is the most complex and generic of all. It is a **sender** specialised for the *Open Sound Control* protocol. This is not because there are a lot of arguments and keyword arguments to learn but because using it relies on linking the **sender** to some other objects that will handle incoming or outgoing messages. It has the same body-tail architecture as the others but the arguments are a bit different:
 
 ```python
-O(osc_connexion, address, keyword=value_or_pattern, ...)
+O(osc_connexion, address, keyworp=value_or_pattern, ...)
 ```
 
 We always need to feed an OSC output port and an address. It perfeclty makes perfect sense if you are already familiar with OSC. You can pattern everything except the osc connexion. If you are clever enough, this won't stop you for long though. You will notice that you can do this if you really need to:
@@ -273,10 +268,10 @@ This is the command you must use if you would like to create a new OSC client. T
 Once this is done, you can use `O()` for sending OSC messages to that address:
 ```python
 # Simple address
-O(my_osc, 'loulou', value='1,2,3,4').out()
+O(my_osc, 'loulou', value='1,2,3,4')
 
 # Composed address (_ equals /)
-O(my_osc, 'loulou/yves', value='1,2,3,4').out()
+O(my_osc, 'loulou/yves', value='1,2,3,4')
 
 ```
 Note how `O()` takes an additional argument compared to other senders. You must provide a valid OSC client for it to work because you can have multiple senders sending at different addresses. Everything else is patternable like usual.
@@ -288,7 +283,7 @@ You can also receive and track incoming OSC values. In fact, you can even attach
 ```python
 info = Receiver(25000)
 def funny_sound():
-    S('bip', shape=0.9, room=0.9).out()
+    D('bip', shape=0.9, room=0.9)
 info.attach('/bip/', funny_sound)
 ```
 
@@ -314,16 +309,16 @@ If you are receiving something, you can now use it in your patterns to map a cap
 info = Receiver(25000)
 info.watch('/sitar/speed/')
 
-@swim 
-def contamination(d=0.5, i=0):
+@swim
+def contamination(p=0.5, i=0):
     v.a = info.get('/sitar/speed/')['args'][0]
-    S('sitar', speed='v.a').out()
-    a(contamination, d=0.5, i=i+1)
+    D('sitar', speed='V.a')
+    a(contamination, p=0.5, i=i+1)
 ```
 
 This opens up the way for environmental reactive patterns that can be modified on-the-fly and that will blend code and human interaction. Handling data received from **OSC** can be a bit tricky at first:
 
-- if you wish to carefully take care of the data you receive, please use the `.attach()` method to attach a callback to every message received and properly handle the data yourself. Use the form `callback(*args, **kwargs)` and examine what data you receive in the *args* and *kwargs*. Map this to global variables, etc... 
+- if you wish to carefully take care of the data you receive, please use the `.attach()` method to attach a callback to every message received and properly handle the data yourself. Use the form `callback(*args, **kwargs)` and examine what data you receive in the *args* and *kwargs*. Map this to global variables, etc...
 
 - if you don't care and just want to watch values as they go, please use the `.watch()` value but you will have to resort to using dictionnary  key access just like I do in the example above. You will have to handle cases where no data is received or cases where the received value is not of the right type. There is no memory of old messages, only the most recent one is kept in memory!
 

--- a/docs/technical/installation.md
+++ b/docs/technical/installation.md
@@ -232,13 +232,13 @@ If you have opted to use the **SuperDirt** audio backend, you can start checking
 if everything is fine by playing a *clap* or a *kickdrum*:
 
 ```python
-S('cp').out()
+D('cp')
 ```
 
 If you want to play a note on your MIDI Synth, use this command instead:
 
 ```python
-M().out()
+N()
 ```
 
 If you hear the clap or the note you were expecting, you are good to go! Have fun!

--- a/sardine/sequences/sardine_parser/sardine.lark
+++ b/sardine/sequences/sardine_parser/sardine.lark
@@ -32,13 +32,13 @@ pattern: sum ("," sum?)* -> return_pattern
      | "$" "." "m"                                         -> get_measure
      | "$" "." "p"                                         -> get_phase
      | "r"                                                 -> get_random_number
-     | "i" "." LETTER                                      -> get_iterator
-     | "i" "." LETTER "=" sum                              -> set_iterator
-     | "i" "." LETTER "=" "[" sum "," sum "]"              -> set_iterator_step
-     | "i" "." LETTER "." "reset"                          -> reset_iterator
-     | "v" "." LETTER                                      -> get_variable
-     | "v" "." LETTER "=" sum                              -> set_variable
-     | "v" "." LETTER "." "reset"                          -> reset_variable
+     | "I" "." LETTER                                      -> get_iterator
+     | "I" "." LETTER "=" sum                              -> set_iterator
+     | "I" "." LETTER "=" "[" sum "," sum "]"              -> set_iterator_step
+     | "I" "." LETTER "." "reset"                          -> reset_iterator
+     | "V" "." LETTER                                      -> get_variable
+     | "V" "." LETTER "=" sum                              -> set_variable
+     | "V" "." LETTER "." "reset"                          -> reset_variable
      | "T" "." "U"                                         -> get_unix_time
      | "T" "." "Y"                                         -> get_year
      | "T" "." "M"                                         -> get_month


### PR DESCRIPTION
## Description

This PR aims at updating the user documentation after v0.2 rewrite since it introduced several syntax changes.

Syntax changes to document: 
- [x] hush -> silence
- [x] S(), M() -> D(), N() (senders)
- [x] out() tail method disappeared
- [x] duration -> period
- [x] div -> d
- [x] i, v -> I, V (amphibian variables and iterators)