### PR TITLE
Rewrite OSCLoop to run in the event loop's thread

### DIFF
--- a/sardine/handlers/osc_loop.py
+++ b/sardine/handlers/osc_loop.py
@@ -1,19 +1,22 @@
+import asyncio
+
 from osc4py3.as_eventloop import osc_process, osc_startup, osc_terminate
 
-from ..base import BaseRunnerHandler, BaseThreadedLoopMixin
+from ..base import BaseRunnerHandler
 
 __all__ = ("OSCLoop",)
 
 
-class OSCLoop(BaseThreadedLoopMixin, BaseRunnerHandler):
-    def __init__(self, *, loop_interval: float = 0.001):
-        super().__init__(loop_interval=loop_interval)
+class OSCLoop(BaseRunnerHandler):
+    def __init__(self, *args, loop_interval: float = 0.001, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.loop_interval = loop_interval
 
-    def before_loop(self):
+    async def run(self):
         osc_startup()
-
-    def loop(self):
-        osc_process()
-
-    def after_loop(self):
-        osc_terminate()
+        try:
+            while True:
+                osc_process()
+                await asyncio.sleep(self.loop_interval)
+        finally:
+            osc_terminate()


### PR DESCRIPTION
Certain callbacks depend on the event loop, e.g. call_timed() invoked by senders, making this change a necessity for those to work.

This change may impact the performance of the event loop. However, idle CPU usage was low to begin with so this likely will not lead to a significant difference.