### PR TITLE
Fix MIDI note duration handling

### DIFF
--- a/sardine_core/fish_bowl.py
+++ b/sardine_core/fish_bowl.py
@@ -173,6 +173,11 @@ class FishBowl:
         """
         return await self.sleeper.sleep(duration)
 
+    async def sleep_beats(self, beats: Union[int, float]):
+        """Sleeps for the given number of beats.
+        """
+        return await self.sleep(beats * self.clock.beat_duration)
+
     # Hot-swap methods ############################################################
 
     def swap_clock(self, clock: "BaseClock"):

--- a/sardine_core/handlers/midi.py
+++ b/sardine_core/handlers/midi.py
@@ -169,7 +169,7 @@ class MidiHandler(Sender):
     async def send_off(
         self, note: int, channel: int, velocity: int, delay: Union[int, float]
     ):
-        await self.env.sleep(delay)
+        await self.env.sleep_beats(delay)
         self._midi.send(
             mido.Message("note_off", note=note, channel=channel, velocity=velocity)
         )
@@ -223,7 +223,7 @@ class MidiHandler(Sender):
         self.active_notes[key] = asyncio.create_task(
             self.send_off(
                 note=pattern["note"],
-                delay=pattern["duration"] - 0.02,
+                delay=pattern["duration"],
                 velocity=pattern["velocity"],
                 channel=pattern["channel"],
             )


### PR DESCRIPTION
Although the docs state that the `duration` parameter is in beats, in practice it was in seconds. This commit adds a `sleep_beats` method to the FishBowl, which is called instead of sleep in the `send_off` method of `MidiHandler`.