### PR TITLE
Fix occasional double iterations when reloading runners

### DIFF
--- a/sardine_core/handlers/player.py
+++ b/sardine_core/handlers/player.py
@@ -175,6 +175,15 @@ class Player(BaseHandler):
             self.iterator = pattern.iterator
             pattern.iterator = None
 
+        import math
+        clock = self.runner.clock
+        is_repeated = math.isclose(clock.shifted_time, self.last_shifted_time, abs_tol=1e-3)
+        print(
+            f"{self.name} {clock.shifted_time = :6.3f} {clock.time = :6.3f}, "
+            f"{self.iterator = :3d} {' X'[is_repeated]}"
+        )
+        self.last_shifted_time = clock.shifted_time
+
         dur = pattern.send_method(
             *pattern.args,
             **pattern.kwargs,
@@ -231,6 +240,7 @@ class Player(BaseHandler):
 
         self.env.scheduler.start_runner(self.runner)
         self.runner.reload()
+        self.last_shifted_time = self.runner.clock.shifted_time
 
     def again(self, *args, **kwargs):
         self.runner.update_state(*args, **kwargs)

--- a/sardine_core/handlers/player.py
+++ b/sardine_core/handlers/player.py
@@ -175,15 +175,6 @@ class Player(BaseHandler):
             self.iterator = pattern.iterator
             pattern.iterator = None
 
-        import math
-        clock = self.runner.clock
-        is_repeated = math.isclose(clock.shifted_time, self.last_shifted_time, abs_tol=1e-3)
-        print(
-            f"{self.name} {clock.shifted_time = :6.3f} {clock.time = :6.3f}, "
-            f"{self.iterator = :3d} {' X'[is_repeated]}"
-        )
-        self.last_shifted_time = clock.shifted_time
-
         dur = pattern.send_method(
             *pattern.args,
             **pattern.kwargs,
@@ -240,7 +231,6 @@ class Player(BaseHandler):
 
         self.env.scheduler.start_runner(self.runner)
         self.runner.reload()
-        self.last_shifted_time = self.runner.clock.shifted_time
 
     def again(self, *args, **kwargs):
         self.runner.update_state(*args, **kwargs)

--- a/sardine_core/scheduler/async_runner.py
+++ b/sardine_core/scheduler/async_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import heapq
 import inspect
+import math
 import traceback
 from collections import deque
 from dataclasses import dataclass
@@ -556,7 +557,10 @@ class AsyncRunner:
             if (
                 self.clock.time >= entry.deadline
                 or state is not None
-                and deadline >= entry.deadline
+                and (
+                    deadline > entry.deadline
+                    or math.isclose(deadline, entry.deadline, rel_tol=0.0, abs_tol=1e-8)
+                )
             ):
                 heapq.heappop(self.deferred_states)
 

--- a/sardine_core/scheduler/async_runner.py
+++ b/sardine_core/scheduler/async_runner.py
@@ -477,11 +477,9 @@ class AsyncRunner:
         # which would cause an unusually long gap between iterations.
         #
         # If this is called after the expected time has already passed,
-        # we should assume we're continuing from the last iteration and
-        # ignore whatever the time is.
-        # This allows returning an overdue deadline if we somehow exceeded
-        # the new interval (such as caused by a high delta), allowing missed
-        # iterations to fire ASAP.
+        # we should continue from that iteration and ignore the current time.
+        # This allows returning an overdue deadline potentially caused by a
+        # high delta, letting missed iterations fire ASAP.
         #
         # Given the above requirements, this would be the ideal solution:
         #     time = min(self.clock.time, self._expected_time)

--- a/sardine_core/scheduler/async_runner.py
+++ b/sardine_core/scheduler/async_runner.py
@@ -1,7 +1,6 @@
 import asyncio
 import heapq
 import inspect
-import math
 import traceback
 from collections import deque
 from dataclasses import dataclass
@@ -557,10 +556,7 @@ class AsyncRunner:
             if (
                 self.clock.time >= entry.deadline
                 or state is not None
-                and (
-                    deadline > entry.deadline
-                    or math.isclose(deadline, entry.deadline, rel_tol=0.0, abs_tol=1e-8)
-                )
+                and deadline >= entry.deadline - 1e-8
             ):
                 heapq.heappop(self.deferred_states)
 


### PR DESCRIPTION
## Description

This PR fixes runners occasionally running more than once in a single iteration, causing players to go out of phase.

## Todo

- [x] Do more heavy testing to verify fix
- [x] Revert debug commit b34ec985610c374ff5af07878b139ae93cc3d4a9