### PR TITLE
Fix mini grammar escape warnings

### DIFF
--- a/sardine_core/sequences/tidal_parser/mini/grammar.py
+++ b/sardine_core/sequences/tidal_parser/mini/grammar.py
@@ -116,7 +116,7 @@ grammar = Grammar(
     #
     # A primitive is a simple token like a word (string) or a number (real or
     # integer).
-    word = ~"[-\w]+"
+    word = ~"[-\\w]+"
     number = real / integer
     real = integer '.' pos_integer?
     pos_real = pos_integer '.' pos_integer?
@@ -126,6 +126,6 @@ grammar = Grammar(
 
     ## Misc
     minus = '-'
-    ws = ~"\s+"
+    ws = ~"\\s+"
     """
 )


### PR DESCRIPTION
Summary:
- escape the regex backslashes inside the Parsimonious mini-notation grammar
- keep the word and whitespace regex semantics unchanged while avoiding invalid escape warnings

Related issues:
- Closes #264

Validation:
- git diff --check
- git diff --cached --check
- git show --check --stat --oneline HEAD
- Not run locally: project test suite