### PR TITLE
Add sardine-web install hint

### DIFF
--- a/sardine/__main__.py
+++ b/sardine/__main__.py
@@ -47,7 +47,34 @@ CONTEXT_SETTINGS = {
 }
 
 
+SARDINE_WEB_INSTALL_HINT = (
+    "The `sardine web` command is provided by the optional `sardine-web` package.\n"
+    "Install it with `python -m pip install sardine-web`, then run `sardine web` again."
+)
+
+
+def _missing_web_command() -> click.Command:
+    @click.command(
+        "web",
+        short_help="Install sardine-web to enable this command",
+        help="Show installation instructions for the optional Sardine Web editor.",
+    )
+    def web():
+        raise click.ClickException(SARDINE_WEB_INSTALL_HINT)
+
+    return web
+
+
+class SardineGroup(click.Group):
+    def get_command(self, ctx: click.Context, cmd_name: str):
+        command = super().get_command(ctx, cmd_name)
+        if command is None and cmd_name == "web":
+            return _missing_web_command()
+        return command
+
+
 @click.group(
+    cls=SardineGroup,
     context_settings=CONTEXT_SETTINGS,
     help="Starts sardine in an asyncio REPL.",
     invoke_without_command=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from click.testing import CliRunner
+
+from sardine.__main__ import main
+
+
+def test_web_command_hint_when_sardine_web_is_missing():
+    result = CliRunner().invoke(main, ["web"])
+
+    assert result.exit_code != 0
+    assert "sardine-web" in result.output
+    assert "python -m pip install sardine-web" in result.output


### PR DESCRIPTION
Summary:
- add a fallback `web` Click command when the optional `sardine-web` hook is not installed
- show an install hint for `python -m pip install sardine-web` instead of the generic missing-command error
- add a CLI regression covering the missing `sardine-web` hint

Related issues:
- Closes #263

Validation:
- `rg -n "SARDINE_WEB_INSTALL_HINT|SardineGroup|missing_web|sardine-web|test_web_command" sardine/__main__.py tests/test_cli.py`
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`
- Not run locally: project test suite
